### PR TITLE
Update size checkpoints in potts modules

### DIFF
--- a/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
@@ -13,6 +13,9 @@ import static arcade.potts.util.PottsEnums.Phase;
  */
 
 public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
+    /** Threshold for critical volume size checkpoint. */
+    static final double SIZE_CHECKPOINT = 0.95;
+    
     /** Target ratio of critical volume for early apoptosis size checkpoint. */
     static final double EARLY_SIZE_TARGET = 0.99;
     
@@ -102,6 +105,8 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
     void stepLate(MersenneTwisterFast random, Simulation sim) {
         // Decrease size of cell.
         cell.updateTarget(cytoBlebbingRate, LATE_SIZE_TARGET);
+        boolean sizeCheck = cell.getVolume() >= SIZE_CHECKPOINT
+                * LATE_SIZE_TARGET * cell.getCriticalVolume();
         
         // Decrease size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
@@ -111,8 +116,7 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
         // Check for completion of late phase.
         Poisson poisson = poissonFactory.createPoisson(rateLate, random);
         currentSteps += poisson.nextInt();
-        if (cell.getVolume() <= LATE_SIZE_TARGET * cell.getCriticalVolume()
-                && currentSteps >= stepsLate) {
+        if (currentSteps >= stepsLate && sizeCheck) {
             removeCell(sim);
             setPhase(Phase.APOPTOSED);
         }

--- a/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
@@ -13,11 +13,11 @@ import static arcade.potts.util.PottsEnums.Phase;
  */
 
 public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
-    /** Ratio of critical volume for early apoptosis size checkpoint. */
-    static final double EARLY_SIZE_CHECKPOINT = 0.99;
+    /** Target ratio of critical volume for early apoptosis size checkpoint. */
+    static final double EARLY_SIZE_TARGET = 0.99;
     
-    /** Ratio of critical volume for late apoptosis size checkpoint. */
-    static final double LATE_SIZE_CHECKPOINT = 0.25;
+    /** Target ratio of critical volume for late apoptosis size checkpoint. */
+    static final double LATE_SIZE_TARGET = 0.25;
     
     /** Event rate for early apoptosis (steps/tick). */
     final double rateEarly;
@@ -73,11 +73,11 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
     @Override
     void stepEarly(MersenneTwisterFast random) {
         // Decrease size of cell.
-        cell.updateTarget(waterLossRate, EARLY_SIZE_CHECKPOINT);
+        cell.updateTarget(waterLossRate, EARLY_SIZE_TARGET);
         
         // Decrease size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
-            cell.updateTarget(Region.NUCLEUS, nucleusPyknosisRate, EARLY_SIZE_CHECKPOINT);
+            cell.updateTarget(Region.NUCLEUS, nucleusPyknosisRate, EARLY_SIZE_TARGET);
         }
         
         // Check for phase transition.
@@ -101,7 +101,7 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
     @Override
     void stepLate(MersenneTwisterFast random, Simulation sim) {
         // Decrease size of cell.
-        cell.updateTarget(cytoBlebbingRate, LATE_SIZE_CHECKPOINT);
+        cell.updateTarget(cytoBlebbingRate, LATE_SIZE_TARGET);
         
         // Decrease size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
@@ -111,7 +111,7 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
         // Check for completion of late phase.
         Poisson poisson = poissonFactory.createPoisson(rateLate, random);
         currentSteps += poisson.nextInt();
-        if (cell.getVolume() <= LATE_SIZE_CHECKPOINT * cell.getCriticalVolume()
+        if (cell.getVolume() <= LATE_SIZE_TARGET * cell.getCriticalVolume()
                 && currentSteps >= stepsLate) {
             removeCell(sim);
             setPhase(Phase.APOPTOSED);

--- a/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
@@ -105,7 +105,7 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
     void stepLate(MersenneTwisterFast random, Simulation sim) {
         // Decrease size of cell.
         cell.updateTarget(cytoBlebbingRate, LATE_SIZE_TARGET);
-        boolean sizeCheck = cell.getVolume() >= SIZE_CHECKPOINT
+        boolean sizeCheck = cell.getVolume() <= SIZE_CHECKPOINT
                 * LATE_SIZE_TARGET * cell.getCriticalVolume();
         
         // Decrease size of nucleus (if cell has regions).

--- a/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
@@ -162,7 +162,7 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         // Increase size of cell.
         cell.updateTarget(cellGrowthRate, SIZE_TARGET);
         boolean sizeCheck = cell.getVolume() >= SIZE_CHECKPOINT
-                * SIZE_TARGET *  cell.getCriticalVolume();
+                * SIZE_TARGET * cell.getCriticalVolume();
         
         // Increase size of nucleus (if cell has regions).
         boolean sizeRegionCheck = true;

--- a/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
@@ -17,8 +17,11 @@ import static arcade.potts.util.PottsEnums.Phase;
  */
 
 public class PottsModuleProliferationSimple extends PottsModuleProliferation {
-    /** Ratio of critical volume for size checkpoint. */
-    static final double SIZE_CHECKPOINT = 2 * 0.95;
+    /** Threshold for critical volume size checkpoint. */
+    static final double SIZE_CHECKPOINT = 0.95;
+    
+    /** Target ratio of critical volume for division size checkpoint. */
+    static final double SIZE_TARGET = 2;
     
     /** Event rate for G1 phase (steps/tick). */
     final double rateG1;
@@ -98,12 +101,12 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         }
         
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, 2);
+        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
         
         // Increase size of nucleus (if cell has regions).
         if (cell.hasRegions()
                 && cell.getVolume(Region.NUCLEUS) > cell.getCriticalVolume(Region.NUCLEUS)) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, 2);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
         }
         
         // Check for phase transition.
@@ -124,11 +127,11 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
     @Override
     void stepS(MersenneTwisterFast random) {
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, 2);
+        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
         
         // Increase size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, 2);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
         }
         
         // Check for phase transition.
@@ -157,15 +160,16 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         }
         
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, 2);
-        boolean sizeCheck = cell.getVolume() >= SIZE_CHECKPOINT * cell.getCriticalVolume();
+        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
+        boolean sizeCheck = cell.getVolume() >= SIZE_CHECKPOINT
+                * SIZE_TARGET *  cell.getCriticalVolume();
         
         // Increase size of nucleus (if cell has regions).
         boolean sizeRegionCheck = true;
         if (cell.hasRegions()) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, 2);
-            sizeRegionCheck = cell.getVolume(Region.NUCLEUS)
-                    >= SIZE_CHECKPOINT * cell.getCriticalVolume(Region.NUCLEUS);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
+            sizeRegionCheck = cell.getVolume(Region.NUCLEUS) >= SIZE_CHECKPOINT
+                    * SIZE_TARGET * cell.getCriticalVolume(Region.NUCLEUS);
         }
         
         // Check for phase transition.
@@ -188,7 +192,7 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
     @Override
     void stepM(MersenneTwisterFast random, Simulation sim) {
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, 2);
+        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
         
         // Update size of nucleus (if cell has regions).
         if (cell.hasRegions()) {

--- a/test/arcade/potts/agent/module/PottsModuleApoptosisSimpleTest.java
+++ b/test/arcade/potts/agent/module/PottsModuleApoptosisSimpleTest.java
@@ -55,6 +55,10 @@ public class PottsModuleApoptosisSimpleTest {
         parameters.put("apoptosis/RATE_LATE", randomDoubleBetween(1, 10));
         parameters.put("apoptosis/STEPS_EARLY", randomIntBetween(1, 100));
         parameters.put("apoptosis/STEPS_LATE", randomIntBetween(1, 100));
+        parameters.put("apoptosis/WATER_LOSS_RATE", randomDoubleBetween(100, 500));
+        parameters.put("apoptosis/CYTOPLASMIC_BLEBBING_RATE", randomDoubleBetween(100, 500));
+        parameters.put("apoptosis/NUCLEUS_PYKNOSIS_RATE", randomDoubleBetween(0, 100));
+        parameters.put("apoptosis/NUCLEUS_FRAGMENTATION_RATE", randomDoubleBetween(0, 100));
     }
     
     @Test
@@ -67,6 +71,11 @@ public class PottsModuleApoptosisSimpleTest {
         assertEquals(parameters.getDouble("apoptosis/RATE_LATE"), module.rateLate, EPSILON);
         assertEquals(parameters.getDouble("apoptosis/STEPS_EARLY"), module.stepsEarly, EPSILON);
         assertEquals(parameters.getDouble("apoptosis/STEPS_LATE"), module.stepsLate, EPSILON);
+        assertEquals(parameters.getDouble("apoptosis/WATER_LOSS_RATE"), module.waterLossRate, EPSILON);
+        assertEquals(parameters.getDouble("apoptosis/CYTOPLASMIC_BLEBBING_RATE"), module.cytoBlebbingRate, EPSILON);
+        assertEquals(parameters.getDouble("apoptosis/NUCLEUS_PYKNOSIS_RATE"), module.nucleusPyknosisRate, EPSILON);
+        assertEquals(parameters.getDouble("apoptosis/NUCLEUS_FRAGMENTATION_RATE"),
+                module.nucleusFragmentationRate, EPSILON);
     }
     
     @Test
@@ -125,7 +134,7 @@ public class PottsModuleApoptosisSimpleTest {
         module.currentSteps = 0;
         module.stepEarly(random);
         
-        verify(cell, times(2)).updateTarget(module.waterLossRate, EARLY_SIZE_CHECKPOINT);
+        verify(cell, times(2)).updateTarget(module.waterLossRate, EARLY_SIZE_TARGET);
     }
     
     @Test
@@ -144,7 +153,7 @@ public class PottsModuleApoptosisSimpleTest {
         module.currentSteps = 0;
         module.stepEarly(random);
         
-        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusPyknosisRate, EARLY_SIZE_CHECKPOINT);
+        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusPyknosisRate, EARLY_SIZE_TARGET);
     }
     
     @Test
@@ -153,7 +162,7 @@ public class PottsModuleApoptosisSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * LATE_SIZE_CHECKPOINT) - 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) - 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
@@ -179,7 +188,7 @@ public class PottsModuleApoptosisSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * LATE_SIZE_CHECKPOINT) - 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) - 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
@@ -206,7 +215,7 @@ public class PottsModuleApoptosisSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * LATE_SIZE_CHECKPOINT) + 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) + 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
@@ -232,7 +241,7 @@ public class PottsModuleApoptosisSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * LATE_SIZE_CHECKPOINT) + 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) + 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
@@ -269,7 +278,7 @@ public class PottsModuleApoptosisSimpleTest {
         module.currentSteps = 0;
         module.stepLate(random, simMock);
         
-        verify(cell, times(2)).updateTarget(module.cytoBlebbingRate, LATE_SIZE_CHECKPOINT);
+        verify(cell, times(2)).updateTarget(module.cytoBlebbingRate, LATE_SIZE_TARGET);
     }
     
     @Test

--- a/test/arcade/potts/agent/module/PottsModuleProliferationSimpleTest.java
+++ b/test/arcade/potts/agent/module/PottsModuleProliferationSimpleTest.java
@@ -181,7 +181,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepG1(random);
         
-        verify(cell, times(2)).updateTarget(module.cellGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(module.cellGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -205,7 +205,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepG1(random);
         
-        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -288,7 +288,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepS(random);
         
-        verify(cell, times(2)).updateTarget(module.cellGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(module.cellGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -307,7 +307,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepS(random);
         
-        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -357,7 +357,7 @@ public class PottsModuleProliferationSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT) + 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * SIZE_TARGET) + 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleProliferationSimple module = spy(new PottsModuleProliferationSimple(cell));
@@ -381,7 +381,7 @@ public class PottsModuleProliferationSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT) + 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * SIZE_TARGET) + 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleProliferationSimple module = spy(new PottsModuleProliferationSimple(cell));
@@ -406,7 +406,7 @@ public class PottsModuleProliferationSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT) - 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * SIZE_TARGET) - 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleProliferationSimple module = spy(new PottsModuleProliferationSimple(cell));
@@ -433,11 +433,11 @@ public class PottsModuleProliferationSimpleTest {
         doReturn(true).when(cell).hasRegions();
         
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT) + 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * SIZE_TARGET) + 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         double regionVolume = randomDoubleBetween(0, 100);
-        doReturn((regionVolume * SIZE_CHECKPOINT) - 1).when(cell).getVolume(Region.NUCLEUS);
+        doReturn((regionVolume * SIZE_CHECKPOINT * SIZE_TARGET) - 1).when(cell).getVolume(Region.NUCLEUS);
         doReturn(regionVolume).when(cell).getCriticalVolume(Region.NUCLEUS);
         
         PottsModuleProliferationSimple module = spy(new PottsModuleProliferationSimple(cell));
@@ -461,7 +461,7 @@ public class PottsModuleProliferationSimpleTest {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
         double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT) - 1).when(cell).getVolume();
+        doReturn((volume * SIZE_CHECKPOINT * SIZE_TARGET) - 1).when(cell).getVolume();
         doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleProliferationSimple module = spy(new PottsModuleProliferationSimple(cell));
@@ -495,7 +495,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepG2(random);
         
-        verify(cell, times(2)).updateTarget(module.cellGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(module.cellGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -514,7 +514,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepG2(random);
         
-        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(Region.NUCLEUS, module.nucleusGrowthRate, SIZE_TARGET);
     }
     
     @Test
@@ -578,7 +578,7 @@ public class PottsModuleProliferationSimpleTest {
         module.currentSteps = 0;
         module.stepM(random, simMock);
         
-        verify(cell, times(2)).updateTarget(module.cellGrowthRate, 2);
+        verify(cell, times(2)).updateTarget(module.cellGrowthRate, SIZE_TARGET);
     }
     
     @Test


### PR DESCRIPTION
- Update `PottsModuleProliferationSimple` to separate the target size scaling and the checkpoint
- Update `PottsModuleApoptosisSimple` to match structure of  `PottsModuleProliferationSimple` 
- Update corresponding tests with new constant names