### PR TITLE
Swap voxel update order

### DIFF
--- a/src/arcade/potts/sim/Potts.java
+++ b/src/arcade/potts/sim/Potts.java
@@ -161,14 +161,14 @@ public abstract class Potts implements Steppable {
             
             // Select unique ID (if there is one), otherwise select unique
             // region (if there is one). If there are neither, then skip.
-            if (hasRegionsCell && uniqueRegionTargets.size() > 0) {
-                int i = simstate.random.nextInt(uniqueRegionTargets.size());
-                int targetRegion = (int) uniqueRegionTargets.toArray()[i];
-                flip(ids[z][x][y], regions[z][x][y], targetRegion, x, y, z, r);
-            } else if (uniqueIDTargets.size() > 0) {
+            if (uniqueIDTargets.size() > 0) {
                 int i = simstate.random.nextInt(uniqueIDTargets.size());
                 int targetID = (int) uniqueIDTargets.toArray()[i];
                 flip(ids[z][x][y], targetID, x, y, z, r);
+            } else if (hasRegionsCell && uniqueRegionTargets.size() > 0) {
+                int i = simstate.random.nextInt(uniqueRegionTargets.size());
+                int targetRegion = (int) uniqueRegionTargets.toArray()[i];
+                flip(ids[z][x][y], regions[z][x][y], targetRegion, x, y, z, r);
             }
         }
     }

--- a/src/arcade/potts/sim/input/PottsInputBuilder.java
+++ b/src/arcade/potts/sim/input/PottsInputBuilder.java
@@ -117,16 +117,12 @@ public final class PottsInputBuilder extends InputBuilder {
     public void endElement(String uri, String local, String name) {
         LOGGER.fine("end element [ " + name + " ]");
         
-        switch (name) {
-            case "series":
-                series.add(new PottsSeries(setupDicts, setupLists, path, parameters, isVis));
-                MiniBox set = setupDicts.get("set");
-                setupDicts = new HashMap<>();
-                setupLists = new HashMap<>();
-                setupDicts.put("set", set);
-                break;
-            default:
-                break;
+        if ("series".equals(name)) {
+            series.add(new PottsSeries(setupDicts, setupLists, path, parameters, isVis));
+            MiniBox set = setupDicts.get("set");
+            setupDicts = new HashMap<>();
+            setupLists = new HashMap<>();
+            setupDicts.put("set", set);
         }
     }
 }


### PR DESCRIPTION
Previous implementation prioritized region voxels over cell voxels when selecting the voxel to flip. Voxel selection now prioritizes cell voxels over region voxels.