### PR TITLE
Update workflows conditions for main and develop branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
         target-folder: _badges
         clean: false
 
-  result:
-    if: ${{ always() }}
+  build_result:
+    if: ${{ always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
 
 jobs:
   documentation:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,26 @@ jobs:
         checkstyle_config: .github/config/checks.xml
         fail_on_error: true
 
+  lint_result:
+    if: ${{ always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') }}
+
+    runs-on: ubuntu-latest
+
+    needs: [lint]
+
+    steps:
+
+    - name: Checkout the repo
+      uses: actions/checkout@v4
+
+    - name: Get lint result
+      run: |
+        if [[ ${{ needs.lint.result }} == "success" || ${{ needs.lint.result }} == "skipped" ]]; then
+          exit 0
+        else
+          exit 1
+        fi
+
     - name: Generate passing badge
       if: success()
       uses: knightdave/anybadge-action@v1.1.0


### PR DESCRIPTION
Update workflows with the following:

- `docs` only runs on `main`
- `lint` runs on all pushes, but only generates badges on `main` and `develop`
- `build` runs on all pushes, but only generates badges on `main` and `develop`