### PR TITLE
Added CLASS as key in population MiniBox in PottsSeries.java

### DIFF
--- a/src/arcade/potts/sim/PottsSeries.java
+++ b/src/arcade/potts/sim/PottsSeries.java
@@ -16,44 +16,43 @@ import static arcade.potts.util.PottsEnums.Term;
 public final class PottsSeries extends Series {
     /** Separator character for targets. */
     public static final String TARGET_SEPARATOR = ":";
-
+    
     /** Map of potts settings. */
     public MiniBox potts;
-
+    
     /** List of Hamiltonian terms. */
     public ArrayList<Term> terms;
-
+    
     /**
      * Creates a {@code Series} object given setup information parsed from XML.
      *
-     * @param setupDicts the map of attribute to value for single instance tags
-     * @param setupLists the map of attribute to value for multiple instance tags
-     * @param path       the path for simulation output
-     * @param parameters the default parameter values
-     * @param isVis      {@code true} if visualized, {@code false} otherwise
+     * @param setupDicts  the map of attribute to value for single instance tags
+     * @param setupLists  the map of attribute to value for multiple instance tags
+     * @param path  the path for simulation output
+     * @param parameters  the default parameter values
+     * @param isVis  {@code true} if visualized, {@code false} otherwise
      */
     public PottsSeries(HashMap<String, MiniBox> setupDicts,
-            HashMap<String, ArrayList<Box>> setupLists,
-            String path, Box parameters, boolean isVis) {
+                       HashMap<String, ArrayList<Box>> setupLists,
+                       String path, Box parameters, boolean isVis) {
         super(setupDicts, setupLists, path, parameters, isVis);
     }
-
+    
     @Override
     protected String getSimClass() {
         return "arcade.potts.sim.PottsSimulation" + (height > 1 ? "3D" : "2D");
     }
-
+    
     @Override
     protected String getVisClass() {
         return "arcade.potts.vis.PottsVisualization";
     }
-
+    
     /**
      * Initializes series simulation, agents, and environment.
      *
-     * @param setupLists the map of attribute to value for multiple instance tags
-     * @param parameters the default parameter values loaded from
-     *                   {@code parameter.xml}
+     * @param setupLists  the map of attribute to value for multiple instance tags
+     * @param parameters  the default parameter values loaded from {@code parameter.xml}
      */
     @Override
     protected void initialize(HashMap<String, ArrayList<Box>> setupLists, Box parameters) {
@@ -62,57 +61,57 @@ public final class PottsSeries extends Series {
         MiniBox populationConversions = parameters.getIdValForTagAtt("POPULATION", "conversion");
         ArrayList<Box> populationsBox = setupLists.get("populations");
         updatePopulations(populationsBox, populationDefaults, populationConversions);
-
+        
         // Initialize layers.
         MiniBox layerDefaults = parameters.getIdValForTag("LAYER");
         MiniBox layerConversions = parameters.getIdValForTagAtt("LAYER", "conversion");
         ArrayList<Box> layersBox = setupLists.get("layers");
         updateLayers(layersBox, layerDefaults, layerConversions);
-
+        
         // Add actions.
         MiniBox actionDefaults = parameters.getIdValForTag("ACTION");
         ArrayList<Box> actionsBox = setupLists.get("actions");
         updateActions(actionsBox, actionDefaults);
-
+        
         // Add components.
         MiniBox componentDefaults = parameters.getIdValForTag("COMPONENT");
         ArrayList<Box> componentsBox = setupLists.get("components");
         updateComponents(componentsBox, componentDefaults);
-
+        
         // Initialize potts.
         MiniBox pottsDefaults = parameters.getIdValForTag("POTTS");
         MiniBox pottsConversions = parameters.getIdValForTagAtt("POTTS", "conversion");
         ArrayList<Box> pottsBox = setupLists.get("potts");
         updatePotts(pottsBox, pottsDefaults, pottsConversions);
     }
-
+    
     /**
      * Calculates potts model parameters.
      *
-     * @param pottsBox         the potts setup dictionary
-     * @param pottsDefaults    the dictionary of default potts parameters
-     * @param pottsConversions the dictionary of potts parameter conversions
+     * @param pottsBox  the potts setup dictionary
+     * @param pottsDefaults  the dictionary of default potts parameters
+     * @param pottsConversions  the dictionary of potts parameter conversions
      */
     void updatePotts(ArrayList<Box> pottsBox, MiniBox pottsDefaults,
-            MiniBox pottsConversions) {
+                     MiniBox pottsConversions) {
         this.potts = new MiniBox();
-
+        
         Box box = new Box();
         if (pottsBox != null && pottsBox.size() == 1 && pottsBox.get(0) != null) {
             box = pottsBox.get(0);
         }
-
+        
         // Get default parameters and any parameter tags.
         Box parameters = box.filterBoxByTag("PARAMETER");
         MiniBox parameterValues = parameters.getIdValForTagAtt("PARAMETER", "value");
         MiniBox parameterScales = parameters.getIdValForTagAtt("PARAMETER", "scale");
-
+        
         // Add in parameters. Start with value (if given) or default (if not
         // given). Then apply any scaling.
         for (String parameter : pottsDefaults.getKeys()) {
             parseParameter(this.potts, parameter, pottsDefaults.get(parameter),
                     parameterValues, parameterScales);
-
+            
             if (parameter.contains(TAG_SEPARATOR)) {
                 for (String pop : populations.keySet()) {
                     parseParameter(this.potts, parameter + TARGET_SEPARATOR + pop,
@@ -120,7 +119,7 @@ public final class PottsSeries extends Series {
                 }
             }
         }
-
+        
         // Add adhesion values for each population and media (*). Values
         // are set as equal to the default (or adjusted) value, before
         // any specific values or scaling is applied.
@@ -128,32 +127,32 @@ public final class PottsSeries extends Series {
             String adhesion = "adhesion/ADHESION" + TARGET_SEPARATOR + source;
             parseParameter(this.potts, adhesion + TARGET_SEPARATOR + "*",
                     this.potts.get(adhesion), parameterValues, parameterScales);
-
+            
             for (String target : populations.keySet()) {
                 parseParameter(this.potts, adhesion + TARGET_SEPARATOR + target,
                         this.potts.get(adhesion), parameterValues, parameterScales);
             }
         }
-
+        
         // Add adhesion values for each population that has regions.
         for (String pop : populations.keySet()) {
             ArrayList<String> regions = populations.get(pop).filter("(REGION)").getKeys();
-
+            
             for (String source : regions) {
                 String adhesion = "adhesion/ADHESION_" + source + TARGET_SEPARATOR + pop;
-
+                
                 for (String target : regions) {
                     parseParameter(this.potts, adhesion + TARGET_SEPARATOR + target,
                             this.potts.get(adhesion), parameterValues, parameterScales);
                 }
             }
         }
-
+        
         // Apply conversion factors.
         for (String convert : pottsConversions.getKeys()) {
             double conversion = parseConversion(pottsConversions.get(convert), ds, dt);
             this.potts.put(convert, this.potts.getDouble(convert) * conversion);
-
+            
             if (convert.contains(TAG_SEPARATOR)) {
                 for (String pop : populations.keySet()) {
                     String convertPop = convert + TARGET_SEPARATOR + pop;
@@ -161,72 +160,70 @@ public final class PottsSeries extends Series {
                 }
             }
         }
-
+        
         // Get list of terms.
         this.terms = new ArrayList<>();
         for (String term : box.filterTags("TERM")) {
             terms.add(Term.valueOf(term.toUpperCase()));
         }
     }
-
+    
     @Override
     protected void updatePopulations(ArrayList<Box> populationsBox, MiniBox populationDefaults,
-            MiniBox populationConversions) {
+                                     MiniBox populationConversions) {
         this.populations = new HashMap<>();
         if (populationsBox == null) {
             return;
         }
-
+        
         // Assign codes to each population.
         int code = 1;
-
+        
         // Iterate through each setup dictionary to build population settings.
         for (Box box : populationsBox) {
             String id = box.getValue("id");
             String populationClass = box.getValue("class");
-
+            
             // Create new population and update code.
             MiniBox population = new MiniBox();
             population.put("CODE", code++);
             population.put("CLASS", populationClass);
             this.populations.put(id, population);
-
+            
             // Add population init if given. If not given or invalid, set to zero.
             if (box.contains("init") && box.getValue("init").contains(":")) {
                 String[] initString = box.getValue("init").split(":");
-
+                
                 box.add("init", initString[0]);
                 box.add("padding", initString[1]);
-
+                
                 int padding = (isValidNumber(box, "padding")
-                        ? (int) Double.parseDouble(box.getValue("padding"))
-                        : 0);
+                        ? (int) Double.parseDouble(box.getValue("padding")) : 0);
                 population.put("PADDING", padding);
             }
-
+            
             int init = (isValidNumber(box, "init")
-                    ? (int) Double.parseDouble(box.getValue("init"))
-                    : 0);
+                    ? (int) Double.parseDouble(box.getValue("init")) : 0);
             population.put("INIT", init);
-
+            
             // Get default parameters and any parameter adjustments.
             Box parameters = box.filterBoxByTag("PARAMETER");
             MiniBox parameterValues = parameters.getIdValForTagAtt("PARAMETER", "value");
             MiniBox parameterScales = parameters.getIdValForTagAtt("PARAMETER", "scale");
-
+            
             // Add in parameters. Start with value (if given) or default (if not
             // given). Then apply any scaling.
             for (String parameter : populationDefaults.getKeys()) {
                 parseParameter(population, parameter, populationDefaults.get(parameter),
                         parameterValues, parameterScales);
             }
-
+            
             // Get list of regions, if valid.
             HashSet<String> regions = box.filterTags("REGION");
             for (String region : regions) {
                 population.put("(REGION)" + TAG_SEPARATOR + region, "");
             }
-
+            
             // Apply conversion factors.
             for (String convert : populationConversions.getKeys()) {
                 double conversion = parseConversion(populationConversions.get(convert), ds, dt);
@@ -234,18 +231,18 @@ public final class PottsSeries extends Series {
             }
         }
     }
-
+    
     @Override
     protected void updateLayers(ArrayList<Box> layersBox, MiniBox layerDefaults,
-            MiniBox layerConversions) {
+                                MiniBox layerConversions) {
         // TODO
     }
-
+    
     @Override
     protected void updateActions(ArrayList<Box> actionsBox, MiniBox actionDefaults) {
         // TODO
     }
-
+    
     @Override
     protected void updateComponents(ArrayList<Box> componentsBox, MiniBox componentDefaults) {
         // TODO

--- a/src/arcade/potts/sim/PottsSeries.java
+++ b/src/arcade/potts/sim/PottsSeries.java
@@ -16,43 +16,44 @@ import static arcade.potts.util.PottsEnums.Term;
 public final class PottsSeries extends Series {
     /** Separator character for targets. */
     public static final String TARGET_SEPARATOR = ":";
-    
+
     /** Map of potts settings. */
     public MiniBox potts;
-    
+
     /** List of Hamiltonian terms. */
     public ArrayList<Term> terms;
-    
+
     /**
      * Creates a {@code Series} object given setup information parsed from XML.
      *
-     * @param setupDicts  the map of attribute to value for single instance tags
-     * @param setupLists  the map of attribute to value for multiple instance tags
-     * @param path  the path for simulation output
-     * @param parameters  the default parameter values
-     * @param isVis  {@code true} if visualized, {@code false} otherwise
+     * @param setupDicts the map of attribute to value for single instance tags
+     * @param setupLists the map of attribute to value for multiple instance tags
+     * @param path       the path for simulation output
+     * @param parameters the default parameter values
+     * @param isVis      {@code true} if visualized, {@code false} otherwise
      */
     public PottsSeries(HashMap<String, MiniBox> setupDicts,
-                       HashMap<String, ArrayList<Box>> setupLists,
-                       String path, Box parameters, boolean isVis) {
+            HashMap<String, ArrayList<Box>> setupLists,
+            String path, Box parameters, boolean isVis) {
         super(setupDicts, setupLists, path, parameters, isVis);
     }
-    
+
     @Override
     protected String getSimClass() {
         return "arcade.potts.sim.PottsSimulation" + (height > 1 ? "3D" : "2D");
     }
-    
+
     @Override
     protected String getVisClass() {
         return "arcade.potts.vis.PottsVisualization";
     }
-    
+
     /**
      * Initializes series simulation, agents, and environment.
      *
-     * @param setupLists  the map of attribute to value for multiple instance tags
-     * @param parameters  the default parameter values loaded from {@code parameter.xml}
+     * @param setupLists the map of attribute to value for multiple instance tags
+     * @param parameters the default parameter values loaded from
+     *                   {@code parameter.xml}
      */
     @Override
     protected void initialize(HashMap<String, ArrayList<Box>> setupLists, Box parameters) {
@@ -61,57 +62,57 @@ public final class PottsSeries extends Series {
         MiniBox populationConversions = parameters.getIdValForTagAtt("POPULATION", "conversion");
         ArrayList<Box> populationsBox = setupLists.get("populations");
         updatePopulations(populationsBox, populationDefaults, populationConversions);
-        
+
         // Initialize layers.
         MiniBox layerDefaults = parameters.getIdValForTag("LAYER");
         MiniBox layerConversions = parameters.getIdValForTagAtt("LAYER", "conversion");
         ArrayList<Box> layersBox = setupLists.get("layers");
         updateLayers(layersBox, layerDefaults, layerConversions);
-        
+
         // Add actions.
         MiniBox actionDefaults = parameters.getIdValForTag("ACTION");
         ArrayList<Box> actionsBox = setupLists.get("actions");
         updateActions(actionsBox, actionDefaults);
-        
+
         // Add components.
         MiniBox componentDefaults = parameters.getIdValForTag("COMPONENT");
         ArrayList<Box> componentsBox = setupLists.get("components");
         updateComponents(componentsBox, componentDefaults);
-        
+
         // Initialize potts.
         MiniBox pottsDefaults = parameters.getIdValForTag("POTTS");
         MiniBox pottsConversions = parameters.getIdValForTagAtt("POTTS", "conversion");
         ArrayList<Box> pottsBox = setupLists.get("potts");
         updatePotts(pottsBox, pottsDefaults, pottsConversions);
     }
-    
+
     /**
      * Calculates potts model parameters.
      *
-     * @param pottsBox  the potts setup dictionary
-     * @param pottsDefaults  the dictionary of default potts parameters
-     * @param pottsConversions  the dictionary of potts parameter conversions
+     * @param pottsBox         the potts setup dictionary
+     * @param pottsDefaults    the dictionary of default potts parameters
+     * @param pottsConversions the dictionary of potts parameter conversions
      */
     void updatePotts(ArrayList<Box> pottsBox, MiniBox pottsDefaults,
-                     MiniBox pottsConversions) {
+            MiniBox pottsConversions) {
         this.potts = new MiniBox();
-        
+
         Box box = new Box();
         if (pottsBox != null && pottsBox.size() == 1 && pottsBox.get(0) != null) {
             box = pottsBox.get(0);
         }
-        
+
         // Get default parameters and any parameter tags.
         Box parameters = box.filterBoxByTag("PARAMETER");
         MiniBox parameterValues = parameters.getIdValForTagAtt("PARAMETER", "value");
         MiniBox parameterScales = parameters.getIdValForTagAtt("PARAMETER", "scale");
-        
+
         // Add in parameters. Start with value (if given) or default (if not
         // given). Then apply any scaling.
         for (String parameter : pottsDefaults.getKeys()) {
             parseParameter(this.potts, parameter, pottsDefaults.get(parameter),
                     parameterValues, parameterScales);
-            
+
             if (parameter.contains(TAG_SEPARATOR)) {
                 for (String pop : populations.keySet()) {
                     parseParameter(this.potts, parameter + TARGET_SEPARATOR + pop,
@@ -119,7 +120,7 @@ public final class PottsSeries extends Series {
                 }
             }
         }
-        
+
         // Add adhesion values for each population and media (*). Values
         // are set as equal to the default (or adjusted) value, before
         // any specific values or scaling is applied.
@@ -127,32 +128,32 @@ public final class PottsSeries extends Series {
             String adhesion = "adhesion/ADHESION" + TARGET_SEPARATOR + source;
             parseParameter(this.potts, adhesion + TARGET_SEPARATOR + "*",
                     this.potts.get(adhesion), parameterValues, parameterScales);
-            
+
             for (String target : populations.keySet()) {
                 parseParameter(this.potts, adhesion + TARGET_SEPARATOR + target,
                         this.potts.get(adhesion), parameterValues, parameterScales);
             }
         }
-        
+
         // Add adhesion values for each population that has regions.
         for (String pop : populations.keySet()) {
             ArrayList<String> regions = populations.get(pop).filter("(REGION)").getKeys();
-            
+
             for (String source : regions) {
                 String adhesion = "adhesion/ADHESION_" + source + TARGET_SEPARATOR + pop;
-                
+
                 for (String target : regions) {
                     parseParameter(this.potts, adhesion + TARGET_SEPARATOR + target,
                             this.potts.get(adhesion), parameterValues, parameterScales);
                 }
             }
         }
-        
+
         // Apply conversion factors.
         for (String convert : pottsConversions.getKeys()) {
             double conversion = parseConversion(pottsConversions.get(convert), ds, dt);
             this.potts.put(convert, this.potts.getDouble(convert) * conversion);
-            
+
             if (convert.contains(TAG_SEPARATOR)) {
                 for (String pop : populations.keySet()) {
                     String convertPop = convert + TARGET_SEPARATOR + pop;
@@ -160,70 +161,72 @@ public final class PottsSeries extends Series {
                 }
             }
         }
-        
+
         // Get list of terms.
         this.terms = new ArrayList<>();
         for (String term : box.filterTags("TERM")) {
             terms.add(Term.valueOf(term.toUpperCase()));
         }
     }
-    
+
     @Override
     protected void updatePopulations(ArrayList<Box> populationsBox, MiniBox populationDefaults,
-                                     MiniBox populationConversions) {
+            MiniBox populationConversions) {
         this.populations = new HashMap<>();
         if (populationsBox == null) {
             return;
         }
-        
+
         // Assign codes to each population.
         int code = 1;
-        
+
         // Iterate through each setup dictionary to build population settings.
         for (Box box : populationsBox) {
             String id = box.getValue("id");
             String populationClass = box.getValue("class");
-            
+
             // Create new population and update code.
             MiniBox population = new MiniBox();
             population.put("CODE", code++);
             population.put("CLASS", populationClass);
             this.populations.put(id, population);
-            
+
             // Add population init if given. If not given or invalid, set to zero.
             if (box.contains("init") && box.getValue("init").contains(":")) {
                 String[] initString = box.getValue("init").split(":");
-                
+
                 box.add("init", initString[0]);
                 box.add("padding", initString[1]);
-                
+
                 int padding = (isValidNumber(box, "padding")
-                        ? (int) Double.parseDouble(box.getValue("padding")) : 0);
+                        ? (int) Double.parseDouble(box.getValue("padding"))
+                        : 0);
                 population.put("PADDING", padding);
             }
-            
+
             int init = (isValidNumber(box, "init")
-                    ? (int) Double.parseDouble(box.getValue("init")) : 0);
+                    ? (int) Double.parseDouble(box.getValue("init"))
+                    : 0);
             population.put("INIT", init);
-            
+
             // Get default parameters and any parameter adjustments.
             Box parameters = box.filterBoxByTag("PARAMETER");
             MiniBox parameterValues = parameters.getIdValForTagAtt("PARAMETER", "value");
             MiniBox parameterScales = parameters.getIdValForTagAtt("PARAMETER", "scale");
-            
+
             // Add in parameters. Start with value (if given) or default (if not
             // given). Then apply any scaling.
             for (String parameter : populationDefaults.getKeys()) {
                 parseParameter(population, parameter, populationDefaults.get(parameter),
                         parameterValues, parameterScales);
             }
-            
+
             // Get list of regions, if valid.
             HashSet<String> regions = box.filterTags("REGION");
             for (String region : regions) {
                 population.put("(REGION)" + TAG_SEPARATOR + region, "");
             }
-            
+
             // Apply conversion factors.
             for (String convert : populationConversions.getKeys()) {
                 double conversion = parseConversion(populationConversions.get(convert), ds, dt);
@@ -231,18 +234,18 @@ public final class PottsSeries extends Series {
             }
         }
     }
-    
+
     @Override
     protected void updateLayers(ArrayList<Box> layersBox, MiniBox layerDefaults,
-                                MiniBox layerConversions) {
+            MiniBox layerConversions) {
         // TODO
     }
-    
+
     @Override
     protected void updateActions(ArrayList<Box> actionsBox, MiniBox actionDefaults) {
         // TODO
     }
-    
+
     @Override
     protected void updateComponents(ArrayList<Box> componentsBox, MiniBox componentDefaults) {
         // TODO

--- a/src/arcade/potts/sim/PottsSeries.java
+++ b/src/arcade/potts/sim/PottsSeries.java
@@ -182,10 +182,12 @@ public final class PottsSeries extends Series {
         // Iterate through each setup dictionary to build population settings.
         for (Box box : populationsBox) {
             String id = box.getValue("id");
+            String populationClass = box.getValue("class");
             
             // Create new population and update code.
             MiniBox population = new MiniBox();
             population.put("CODE", code++);
+            population.put("CLASS", populationClass);
             this.populations.put(id, population);
             
             // Add population init if given. If not given or invalid, set to zero.

--- a/test/arcade/potts/sim/PottsSeriesTest.java
+++ b/test/arcade/potts/sim/PottsSeriesTest.java
@@ -20,30 +20,30 @@ import static arcade.potts.util.PottsEnums.Term;
 
 public class PottsSeriesTest {
     private static final double EPSILON = 1E-10;
-
+    
     private static final double DS = randomDoubleBetween(2, 10);
-
+    
     private static final double DT = randomDoubleBetween(0.5, 2);
-
+    
     private static final Box PARAMETERS = new Box();
-
+    
     private static final String[] REGION_IDS = new String[] {
             randomString().toUpperCase(),
             randomString().toUpperCase(),
     };
-
+    
     private static final String[] MODULE_IDS = new String[] {
             randomString().toLowerCase(),
             randomString().toLowerCase(),
     };
-
+    
     private static final String[] TERM_IDS = new String[] {
             randomString().toLowerCase(),
             randomString().toLowerCase(),
     };
-
+    
     private static final String TERM_ADHESION_PARAMETER = "adhesion" + TAG_SEPARATOR + "ADHESION";
-
+    
     private static final String[] POTTS_PARAMETER_NAMES = new String[] {
             TERM_ADHESION_PARAMETER,
             TERM_ADHESION_PARAMETER + "_" + REGION_IDS[0],
@@ -57,7 +57,7 @@ public class PottsSeriesTest {
             TERM_IDS[0] + TAG_SEPARATOR + "TERM_PARAMETER_11_" + REGION_IDS[1],
             TERM_IDS[1] + TAG_SEPARATOR + "TERM_PARAMETER_11_" + REGION_IDS[0],
     };
-
+    
     private static final String[] POTTS_PARAMETER_TERM_NAMES = new String[] {
             POTTS_PARAMETER_NAMES[6],
             POTTS_PARAMETER_NAMES[7],
@@ -65,7 +65,7 @@ public class PottsSeriesTest {
             POTTS_PARAMETER_NAMES[9],
             POTTS_PARAMETER_NAMES[10],
     };
-
+    
     private static final double[] POTTS_PARAMETER_VALUES = new double[] {
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
@@ -79,9 +79,9 @@ public class PottsSeriesTest {
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
     };
-
+    
     private static final int POTTS_PARAMETER_COUNT = POTTS_PARAMETER_NAMES.length;
-
+    
     private static final String[] POPULATION_PARAMETER_NAMES = new String[] {
             "POPULATION_PARAMETER_1",
             "POPULATION_PARAMETER_2",
@@ -93,7 +93,7 @@ public class PottsSeriesTest {
             REGION_IDS[1] + TAG_SEPARATOR + "POPULATION_PARAMETER_1",
             REGION_IDS[1] + TAG_SEPARATOR + "POPULATION_PARAMETER_2",
     };
-
+    
     private static final double[] POPULATION_PARAMETER_VALUES = new double[] {
             randomDoubleBetween(1, 100),
             randomDoubleBetween(1, 100),
@@ -105,29 +105,29 @@ public class PottsSeriesTest {
             randomDoubleBetween(1, 100),
             randomDoubleBetween(1, 100),
     };
-
+    
     private static final String POPULATION_ID_1 = randomString();
 
     private static final String POPULATION_CLASS_1 = randomString();
-
+    
     private static final String POPULATION_ID_2 = randomString();
 
     private static final String POPULATION_CLASS_2 = randomString();
-
+    
     private static final String POPULATION_ID_3 = randomString();
 
     private static final String POPULATION_CLASS_3 = randomString();
-
+    
     private static final String[] POPULATION_KEYS = new String[] {
             POPULATION_ID_1,
             POPULATION_ID_2,
             POPULATION_ID_3,
     };
-
+    
     private static final MiniBox POTTS = new MiniBox();
-
+    
     private static final MiniBox POPULATION = new MiniBox();
-
+    
     @BeforeClass
     public static void setupParameters() {
         // DEFAULTS
@@ -135,7 +135,7 @@ public class PottsSeriesTest {
         PARAMETERS.addTag("DT", "DEFAULT");
         PARAMETERS.addAtt("DS", "value", "" + DS);
         PARAMETERS.addAtt("DT", "value", "" + DT);
-
+        
         // POTTS
         for (int i = 0; i < POTTS_PARAMETER_COUNT; i++) {
             PARAMETERS.addTag(POTTS_PARAMETER_NAMES[i], "POTTS");
@@ -145,7 +145,7 @@ public class PottsSeriesTest {
         for (String key : potts.getKeys()) {
             POTTS.put(key, potts.get(key));
         }
-
+        
         // POPULATION
         for (int i = 0; i < POPULATION_PARAMETER_NAMES.length; i++) {
             PARAMETERS.addTag(POPULATION_PARAMETER_NAMES[i], "POPULATION");
@@ -156,19 +156,19 @@ public class PottsSeriesTest {
             POPULATION.put(key, population.get(key));
         }
     }
-
+    
     private HashMap<String, ArrayList<Box>> makeLists() {
         HashMap<String, ArrayList<Box>> setupLists = new HashMap<>();
-
+        
         ArrayList<Box> potts = new ArrayList<>();
         setupLists.put("potts", potts);
-
+        
         ArrayList<Box> populations = new ArrayList<>();
         setupLists.put("populations", populations);
-
+        
         return setupLists;
     }
-
+    
     private HashMap<String, MiniBox> makePopulations() {
         HashMap<String, MiniBox> populations = new HashMap<>();
         for (String population : POPULATION_KEYS) {
@@ -176,55 +176,54 @@ public class PottsSeriesTest {
         }
         return populations;
     }
-
+    
     @Test
     public void initialize_default_callsMethods() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.initialize(setupLists, PARAMETERS);
-
+        
         ArrayList<Box> potts = setupLists.get("potts");
         verify(series).updatePotts(eq(potts), any(MiniBox.class), any(MiniBox.class));
-
+        
         ArrayList<Box> populations = setupLists.get("populations");
         verify(series).updatePopulations(eq(populations), any(MiniBox.class), any(MiniBox.class));
-
+        
         ArrayList<Box> layers = setupLists.get("layers");
         verify(series).updateLayers(eq(layers), any(MiniBox.class), any(MiniBox.class));
-
+        
         ArrayList<Box> actions = setupLists.get("actions");
         verify(series).updateActions(eq(actions), any(MiniBox.class));
-
+        
         ArrayList<Box> components = setupLists.get("components");
         verify(series).updateComponents(eq(components), any(MiniBox.class));
     }
-
+    
     private PottsSeries makeSeriesForPotts(Box box) {
         return makeSeriesForPotts(box, new MiniBox());
     }
-
+    
     private PottsSeries makeSeriesForPotts(Box box, MiniBox conversion) {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         ArrayList<Box> potts = setupLists.get("potts");
         potts.add(box);
         series.populations = makePopulations();
-
+        
         try {
             Field dsField = Series.class.getDeclaredField("ds");
             dsField.setAccessible(true);
             dsField.setDouble(series, DS);
-
+            
             Field dtField = Series.class.getDeclaredField("dt");
             dtField.setAccessible(true);
             dtField.setDouble(series, DT);
-        } catch (Exception ignored) {
-        }
-
+        } catch (Exception ignored) { }
+        
         series.updatePotts(potts, POTTS, conversion);
         return series;
     }
-
+    
     @Test
     public void updatePotts_noSetting_createsBox() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
@@ -232,33 +231,33 @@ public class PottsSeriesTest {
         series.updatePotts(null, POTTS, new MiniBox());
         assertNotNull(series.potts);
     }
-
+    
     @Test
     public void updatePotts_noParameters_usesDefaults() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
-
+        
         for (String parameter : POTTS_PARAMETER_NAMES) {
             assertEquals(POTTS.get(parameter), box.get(parameter));
         }
     }
-
+    
     @Test
     public void updatePotts_givenParameters_updatesValues() {
         for (String pottsParameter1 : POTTS_PARAMETER_NAMES) {
             for (String pottsParameter2 : POTTS_PARAMETER_NAMES) {
                 Box potts = new Box();
-
+                
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(pottsParameter1, "value", "" + value);
                 potts.addTag(pottsParameter1, "PARAMETER");
                 potts.addAtt(pottsParameter2, "scale", "" + scale);
                 potts.addTag(pottsParameter2, "PARAMETER");
-
+                
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-
+                
                 for (String parameter : POTTS_PARAMETER_NAMES) {
                     double expected = POTTS.getDouble(parameter);
                     if (parameter.equals(pottsParameter1)) {
@@ -272,35 +271,35 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_noParameters_assignsTargets() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
-
+        
         for (String pop : POPULATION_KEYS) {
             for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                 assertEquals(POTTS.get(parameter), box.get(parameter + TARGET_SEPARATOR + pop));
             }
         }
     }
-
+    
     @Test
     public void updatePotts_givenParameters_assignsTargets() {
         for (String pottsParameter1 : POTTS_PARAMETER_TERM_NAMES) {
             for (String pottsParameter2 : POTTS_PARAMETER_TERM_NAMES) {
                 Box potts = new Box();
-
+                
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(pottsParameter1, "value", "" + value);
                 potts.addTag(pottsParameter1, "PARAMETER");
                 potts.addAtt(pottsParameter2, "scale", "" + scale);
                 potts.addTag(pottsParameter2, "PARAMETER");
-
+                
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-
+                
                 for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                     double expected = POTTS.getDouble(parameter);
                     if (parameter.equals(pottsParameter1)) {
@@ -309,7 +308,7 @@ public class PottsSeriesTest {
                     if (parameter.equals(pottsParameter2)) {
                         expected *= scale;
                     }
-
+                    
                     for (String pop : POPULATION_KEYS) {
                         assertEquals(expected, box.getDouble(parameter + TARGET_SEPARATOR + pop), EPSILON);
                     }
@@ -317,7 +316,7 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_givenPopulationParameters_updatesValues() {
         for (String pottsParameter1 : POTTS_PARAMETER_TERM_NAMES) {
@@ -331,21 +330,21 @@ public class PottsSeriesTest {
                         potts.addTag(pottsParameter1 + TARGET_SEPARATOR + pottsPop1, "PARAMETER");
                         potts.addAtt(pottsParameter2 + TARGET_SEPARATOR + pottsPop2, "scale", "" + scale);
                         potts.addTag(pottsParameter2 + TARGET_SEPARATOR + pottsPop2, "PARAMETER");
-
+                        
                         PottsSeries series = makeSeriesForPotts(potts);
                         MiniBox box = series.potts;
-
+                        
                         for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                             for (String pop : POPULATION_KEYS) {
                                 double expected = POTTS.getDouble(parameter);
-
+                                
                                 if (parameter.equals(pottsParameter1) && pop.equals(pottsPop1)) {
                                     expected = value;
                                 }
                                 if (parameter.equals(pottsParameter2) && pop.equals(pottsPop2)) {
                                     expected *= scale;
                                 }
-
+                                
                                 assertEquals(POTTS.getDouble(parameter), box.getDouble(parameter), EPSILON);
                                 assertEquals(expected, box.getDouble(parameter + TARGET_SEPARATOR + pop), EPSILON);
                             }
@@ -355,17 +354,17 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_withConversion_convertsValue() {
         MiniBox conversion = new MiniBox();
         String convertedParameter = POTTS_PARAMETER_NAMES[3];
         conversion.put(convertedParameter, "DT");
-
+        
         Box potts = new Box();
         PottsSeries series = makeSeriesForPotts(potts, conversion);
         MiniBox box = series.potts;
-
+        
         for (String parameter : POTTS_PARAMETER_NAMES) {
             double expected = POTTS.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -374,18 +373,18 @@ public class PottsSeriesTest {
             assertEquals(expected, box.getDouble(parameter), EPSILON);
         }
     }
-
+    
     @Test
     public void updatePotts_withTermConversion_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POTTS_PARAMETER_TERM_NAMES.length);
         String convertedParameter = POTTS_PARAMETER_TERM_NAMES[i];
         conversion.put(convertedParameter, "DT");
-
+        
         Box potts = new Box();
         PottsSeries series = makeSeriesForPotts(potts, conversion);
         MiniBox box = series.potts;
-
+        
         for (String pop : POPULATION_KEYS) {
             for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                 double expected = POTTS.getDouble(parameter);
@@ -396,37 +395,37 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_noAdhesion_usesDefaults() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
         double adhesion = POTTS.getDouble(TERM_ADHESION_PARAMETER);
-
+        
         assertEquals(adhesion, box.getDouble(TERM_ADHESION_PARAMETER), EPSILON);
-
+        
         for (String source : POPULATION_KEYS) {
             String adhesionSource = TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + source;
             assertEquals(adhesion, box.getDouble(adhesionSource), EPSILON);
             assertEquals(adhesion, box.getDouble(adhesionSource + TARGET_SEPARATOR + "*"), EPSILON);
-
+            
             for (String target : POPULATION_KEYS) {
                 String adhesionTarget = adhesionSource + TARGET_SEPARATOR + target;
                 assertEquals(adhesion, box.getDouble(adhesionTarget), EPSILON);
             }
         }
     }
-
+    
     @Test
     public void updatePotts_givenAdhesion_updateValues() {
         String[] pops = new String[POPULATION_KEYS.length + 1];
         System.arraycopy(POPULATION_KEYS, 0, pops, 0, POPULATION_KEYS.length);
         pops[POPULATION_KEYS.length] = "*";
-
+        
         for (String pop1 : pops) {
             for (String pop2 : pops) {
                 Box potts = new Box();
-
+                
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + pop1, "value", "" + value);
@@ -435,10 +434,10 @@ public class PottsSeriesTest {
                         + pop1 + TARGET_SEPARATOR + pop2, "scale", "" + scale);
                 potts.addTag(TERM_ADHESION_PARAMETER + TARGET_SEPARATOR
                         + pop1 + TARGET_SEPARATOR + pop2, "PARAMETER");
-
+                
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-
+                
                 for (String source : POPULATION_KEYS) {
                     double expected1 = POTTS.getDouble(TERM_ADHESION_PARAMETER);
                     if (source.equals(pop1)) {
@@ -446,7 +445,7 @@ public class PottsSeriesTest {
                     }
                     String adhesionSource = TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + source;
                     assertEquals(expected1, box.getDouble(adhesionSource), EPSILON);
-
+                    
                     for (String target : pops) {
                         double expected2 = expected1;
                         if (source.equals(pop1) && target.equals(pop2)) {
@@ -459,43 +458,43 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_withRegionsNoAdhesion_usesDefaults() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-
+        
         series.populations = makePopulations();
         String key = POPULATION_KEYS[randomIntBetween(0, POPULATION_KEYS.length)];
         MiniBox popBox = series.populations.get(key);
         popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[0], 0);
         popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[1], 0);
-
+        
         series.updatePotts(setupLists.get("potts"), POTTS, new MiniBox());
         MiniBox box = series.potts;
-
+        
         for (String source : REGION_IDS) {
             double adhesion = POTTS.getDouble(TERM_ADHESION_PARAMETER + "_" + source);
             assertEquals(adhesion, box.getDouble(TERM_ADHESION_PARAMETER + "_" + source), EPSILON);
-
+            
             String adhesionSource = TERM_ADHESION_PARAMETER + "_" + source + TARGET_SEPARATOR + key;
             assertEquals(adhesion, box.getDouble(adhesionSource), EPSILON);
-
+            
             for (String target : REGION_IDS) {
                 String adhesionTarget = adhesionSource + TARGET_SEPARATOR + target;
                 assertEquals(adhesion, box.getDouble(adhesionTarget), EPSILON);
             }
         }
     }
-
+    
     @Test
     public void updatePotts_withRegionsGivenAdhesion_updateValues() {
         String key = POPULATION_KEYS[randomIntBetween(0, POPULATION_KEYS.length)];
-
+        
         for (String region1 : REGION_IDS) {
             for (String region2 : REGION_IDS) {
                 Box potts = new Box();
-
+                
                 String adhesion = TERM_ADHESION_PARAMETER + "_" + region1;
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
@@ -505,19 +504,19 @@ public class PottsSeriesTest {
                         + key + TARGET_SEPARATOR + region2, "scale", "" + scale);
                 potts.addTag(adhesion + TARGET_SEPARATOR
                         + key + TARGET_SEPARATOR + region2, "PARAMETER");
-
+                
                 HashMap<String, ArrayList<Box>> setupLists = makeLists();
                 PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-
+                
                 series.populations = makePopulations();
                 MiniBox popBox = series.populations.get(key);
                 popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[0], 0);
                 popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[1], 0);
-
+                
                 setupLists.get("potts").add(potts);
                 series.updatePotts(setupLists.get("potts"), POTTS, new MiniBox());
                 MiniBox box = series.potts;
-
+                
                 for (String source : REGION_IDS) {
                     double expected1 = POTTS.getDouble(TERM_ADHESION_PARAMETER + "_" + source);
                     if (source.equals(region1)) {
@@ -525,7 +524,7 @@ public class PottsSeriesTest {
                     }
                     String adhesionSource = TERM_ADHESION_PARAMETER + "_" + source + TARGET_SEPARATOR + key;
                     assertEquals(expected1, box.getDouble(adhesionSource), EPSILON);
-
+                    
                     for (String target : REGION_IDS) {
                         double expected2 = expected1;
                         if (source.equals(region1) && target.equals(region2)) {
@@ -538,7 +537,7 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePotts_noTerms_createsList() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
@@ -546,64 +545,63 @@ public class PottsSeriesTest {
         series.updatePotts(null, POTTS, new MiniBox());
         assertNotNull(series.terms);
     }
-
+    
     @Test
     public void updatePotts_withTerms_createsList() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.populations = new HashMap<>();
         ArrayList<Box> potts = setupLists.get("potts");
-
+        
         Box box = new Box();
         potts.add(box);
-
+        
         MersenneTwisterFast random = new MersenneTwisterFast();
         Term term1 = Term.random(random);
         Term term2 = Term.random(random);
-
+        
         box.addTag(term1.name(), "TERM");
         box.addTag(term2.name(), "TERM");
-
+        
         series.updatePotts(potts, POTTS, new MiniBox());
-
+        
         int n = (term1.equals(term2) ? 1 : 2);
         assertEquals(n, series.terms.size());
         assertTrue(series.terms.contains(term1));
         assertTrue(series.terms.contains(term2));
     }
-
+    
     private PottsSeries makeSeriesForPopulation(Box[] boxes) {
         return makeSeriesForPopulation(boxes, new MiniBox());
     }
-
+    
     private PottsSeries makeSeriesForPopulation(Box[] boxes, MiniBox conversion) {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         ArrayList<Box> populations = setupLists.get("populations");
         populations.addAll(Arrays.asList(boxes));
-
+        
         try {
             Field dsField = Series.class.getDeclaredField("ds");
             dsField.setAccessible(true);
             dsField.setDouble(series, DS);
-
+            
             Field dtField = Series.class.getDeclaredField("dt");
             dtField.setAccessible(true);
             dtField.setDouble(series, DT);
-        } catch (Exception ignored) {
-        }
-
+        } catch (Exception ignored) { }
+        
         series.updatePopulations(populations, POPULATION, conversion);
         return series;
     }
-
+    
     @Test
     public void updatePopulation_noPopulations_createsMap() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.updatePopulations(null, POPULATION, new MiniBox());
         assertEquals(0, series.populations.size());
     }
-
+    
     @Test
     public void updatePopulation_onePopulation_createsMap() {
         Box[] boxes = new Box[] { new Box() };
@@ -614,7 +612,7 @@ public class PottsSeriesTest {
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
     }
-
+    
     @Test
     public void updatePopulation_multiplePopulations_createsMap() {
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
@@ -622,7 +620,7 @@ public class PottsSeriesTest {
         boxes[1].add("id", POPULATION_ID_2);
         boxes[2].add("id", POPULATION_ID_3);
         PottsSeries series = makeSeriesForPopulation(boxes);
-
+        
         assertEquals(3, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertNotNull(series.populations.get(POPULATION_ID_2));
@@ -642,7 +640,7 @@ public class PottsSeriesTest {
         boxes[2].add("id", POPULATION_ID_3);
         boxes[2].add("class", POPULATION_CLASS_3);
         PottsSeries series = makeSeriesForPopulation(boxes);
-
+        
         assertEquals(3, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertNotNull(series.populations.get(POPULATION_ID_2));
@@ -654,130 +652,130 @@ public class PottsSeriesTest {
         assertEquals(POPULATION_CLASS_2, series.populations.get(POPULATION_ID_2).get("CLASS"));
         assertEquals(POPULATION_CLASS_3, series.populations.get(POPULATION_ID_3).get("CLASS"));
     }
-
+    
     @Test
     public void updatePopulation_noInit_setsZero() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
-
+        
         MiniBox box = series.populations.get(POPULATION_ID_1);
         assertEquals(0, box.getDouble("INIT"), EPSILON);
     }
-
+    
     @Test
     public void updatePopulation_givenValidInit_setsValue() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         int[] values = new int[] { 0, 10, 100 };
-
+        
         for (int i = 0; i < fractions.length; i++) {
             Box[] boxes = new Box[] { new Box() };
             boxes[0].add("id", POPULATION_ID_1);
             boxes[0].add("init", fractions[i]);
             PottsSeries series = makeSeriesForPopulation(boxes);
-
+            
             MiniBox box = series.populations.get(POPULATION_ID_1);
             assertEquals(values[i], box.getInt("INIT"));
         }
     }
-
+    
     @Test
     public void updatePopulation_givenInvalidInit_setsZero() {
         String[] fractions = new String[] { "1.1", "-1" };
-
+        
         for (String fraction : fractions) {
             Box[] boxes = new Box[] { new Box() };
             boxes[0].add("id", POPULATION_ID_1);
             boxes[0].add("init", fraction);
             PottsSeries series = makeSeriesForPopulation(boxes);
-
+            
             MiniBox box = series.populations.get(POPULATION_ID_1);
             assertEquals(0, box.getDouble("INIT"), EPSILON);
         }
     }
-
+    
     @Test
     public void updatePopulation_givenValidPadding_setsValue() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         String[] paddings = new String[] { "0", "10", "1E2" };
         int[] values = new int[] { 0, 10, 100 };
-
+        
         for (int i = 0; i < fractions.length; i++) {
             for (int j = 0; j < paddings.length; j++) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[0].add("init", fractions[i] + ":" + paddings[j]);
                 PottsSeries series = makeSeriesForPopulation(boxes);
-
+                
                 MiniBox box = series.populations.get(POPULATION_ID_1);
                 assertEquals(values[i], box.getInt("INIT"));
                 assertEquals(values[j], box.getInt("PADDING"));
             }
         }
     }
-
+    
     @Test
     public void updatePopulation_givenInvalidPadding_setsZero() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         String[] paddings = new String[] { "1.1", "-1" };
         int[] values = new int[] { 0, 10, 100 };
-
+        
         for (int i = 0; i < fractions.length; i++) {
             for (String padding : paddings) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[0].add("init", fractions[i] + ":" + padding);
                 PottsSeries series = makeSeriesForPopulation(boxes);
-
+                
                 MiniBox box = series.populations.get(POPULATION_ID_1);
                 assertEquals(values[i], box.getInt("INIT"));
                 assertEquals(0, box.getInt("PADDING"));
             }
         }
     }
-
+    
     @Test
     public void updatePopulation_withRegions_setsTags() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         boxes[0].addTag(REGION_IDS[0], "REGION");
-
+        
         PottsSeries series = makeSeriesForPopulation(boxes);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-
+        
         assertEquals("", box.get("(REGION)" + TAG_SEPARATOR + REGION_IDS[0]));
         assertFalse(box.contains("(REGION)" + TAG_SEPARATOR + REGION_IDS[1]));
     }
-
+    
     @Test
     public void updatePopulation_noParametersOnePop_usesDefaults() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-
+        
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             assertEquals(POPULATION.get(parameter), box.get(parameter));
         }
     }
-
+    
     @Test
     public void updatePopulation_givenParametersOnePop_updatesValues() {
         for (String populationParameter1 : POPULATION_PARAMETER_NAMES) {
             for (String populationParameter2 : POPULATION_PARAMETER_NAMES) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
-
+                
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 boxes[0].addAtt(populationParameter1, "value", "" + value);
                 boxes[0].addTag(populationParameter1, "PARAMETER");
                 boxes[0].addAtt(populationParameter2, "scale", "" + scale);
                 boxes[0].addTag(populationParameter2, "PARAMETER");
-
+                
                 PottsSeries series = makeSeriesForPopulation(boxes);
                 MiniBox box = series.populations.get(POPULATION_ID_1);
-
+                
                 for (String parameter : POPULATION_PARAMETER_NAMES) {
                     double expected = POPULATION.getDouble(parameter);
                     if (parameter.equals(populationParameter1)) {
@@ -791,7 +789,7 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePopulation_noParametersMultiplePops_usesDefaults() {
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
@@ -802,14 +800,14 @@ public class PottsSeriesTest {
         MiniBox box1 = series.populations.get(POPULATION_ID_1);
         MiniBox box2 = series.populations.get(POPULATION_ID_2);
         MiniBox box3 = series.populations.get(POPULATION_ID_3);
-
+        
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             assertEquals(POPULATION.get(parameter), box1.get(parameter));
             assertEquals(POPULATION.get(parameter), box2.get(parameter));
             assertEquals(POPULATION.get(parameter), box3.get(parameter));
         }
     }
-
+    
     @Test
     public void updatePopulation_givenParametersMultiplePops_updatesValues() {
         for (String populationParameter1 : POPULATION_PARAMETER_NAMES) {
@@ -818,23 +816,23 @@ public class PottsSeriesTest {
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[1].add("id", POPULATION_ID_2);
                 boxes[2].add("id", POPULATION_ID_3);
-
+                
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 boxes[1].addAtt(populationParameter1, "value", "" + value);
                 boxes[1].addTag(populationParameter1, "PARAMETER");
                 boxes[1].addAtt(populationParameter2, "scale", "" + scale);
                 boxes[1].addTag(populationParameter2, "PARAMETER");
-
+                
                 PottsSeries series = makeSeriesForPopulation(boxes);
                 MiniBox box1 = series.populations.get(POPULATION_ID_1);
                 MiniBox box2 = series.populations.get(POPULATION_ID_2);
                 MiniBox box3 = series.populations.get(POPULATION_ID_3);
-
+                
                 for (String parameter : POPULATION_PARAMETER_NAMES) {
                     assertEquals(POPULATION.get(parameter), box1.get(parameter));
                     assertEquals(POPULATION.get(parameter), box3.get(parameter));
-
+                    
                     double expected = POPULATION.getDouble(parameter);
                     if (parameter.equals(populationParameter1)) {
                         expected = value;
@@ -847,19 +845,19 @@ public class PottsSeriesTest {
             }
         }
     }
-
+    
     @Test
     public void updatePopulation_withConversionOnePop_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POPULATION_PARAMETER_NAMES.length);
         String convertedParameter = POPULATION_PARAMETER_NAMES[i];
         conversion.put(convertedParameter, "DS");
-
+        
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes, conversion);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-
+        
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             double expected = POPULATION.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -868,14 +866,14 @@ public class PottsSeriesTest {
             assertEquals(expected, box.getDouble(parameter), EPSILON);
         }
     }
-
+    
     @Test
     public void updatePopulation_withConversionMultiplePops_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POPULATION_PARAMETER_NAMES.length);
         String convertedParameter = POPULATION_PARAMETER_NAMES[i];
         conversion.put(convertedParameter, "DS");
-
+        
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         boxes[1].add("id", POPULATION_ID_2);
@@ -884,7 +882,7 @@ public class PottsSeriesTest {
         MiniBox box1 = series.populations.get(POPULATION_ID_1);
         MiniBox box2 = series.populations.get(POPULATION_ID_2);
         MiniBox box3 = series.populations.get(POPULATION_ID_3);
-
+        
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             double expected = POPULATION.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -895,37 +893,35 @@ public class PottsSeriesTest {
             assertEquals(expected, box3.getDouble(parameter), EPSILON);
         }
     }
-
+    
     @Test
     public void getSimClass_given2D_returnsClass() {
         String className = PottsSimulation2D.class.getName();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-
+        
         try {
             Field field = Series.class.getDeclaredField("height");
             field.setAccessible(true);
             field.setInt(series, 1);
-        } catch (Exception ignored) {
-        }
-
+        } catch (Exception ignored) { }
+        
         assertEquals(className, series.getSimClass());
     }
-
+    
     @Test
     public void getSimClass_given3D_returnsClass() {
         String className = PottsSimulation3D.class.getName();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-
+        
         try {
             Field field = Series.class.getDeclaredField("height");
             field.setAccessible(true);
             field.setInt(series, 3);
-        } catch (Exception ignored) {
-        }
-
+        } catch (Exception ignored) { }
+        
         assertEquals(className, series.getSimClass());
     }
-
+    
     @Test
     public void getVisClass_allCases_returnsClass() {
         String className = PottsVisualization.class.getName();

--- a/test/arcade/potts/sim/PottsSeriesTest.java
+++ b/test/arcade/potts/sim/PottsSeriesTest.java
@@ -107,15 +107,27 @@ public class PottsSeriesTest {
     };
     
     private static final String POPULATION_ID_1 = randomString();
+
+    private static final String POPULATION_CLASS_1 = randomString();
     
     private static final String POPULATION_ID_2 = randomString();
+
+    private static final String POPULATION_CLASS_2 = randomString();
     
     private static final String POPULATION_ID_3 = randomString();
+
+    private static final String POPULATION_CLASS_3 = randomString();
     
     private static final String[] POPULATION_KEYS = new String[] {
             POPULATION_ID_1,
             POPULATION_ID_2,
             POPULATION_ID_3,
+    };
+
+    private static final String[] POPULATION_CLASSES = new String[] {
+            POPULATION_CLASS_1,
+            POPULATION_CLASS_2,
+            POPULATION_CLASS_3,
     };
     
     private static final MiniBox POTTS = new MiniBox();
@@ -600,8 +612,8 @@ public class PottsSeriesTest {
     public void updatePopulation_onePopulation_createsMap() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
+        boxes[0].add("class", POPULATION_CLASS_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
-        
         assertEquals(1, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
@@ -622,6 +634,29 @@ public class PottsSeriesTest {
         assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
         assertEquals(2, series.populations.get(POPULATION_ID_2).getInt("CODE"));
         assertEquals(3, series.populations.get(POPULATION_ID_3).getInt("CODE"));
+    }
+
+    @Test
+    public void updatePopulation_multiplePopulationsWithClass_createsMap() {
+        Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
+        boxes[0].add("id", POPULATION_ID_1);
+        boxes[0].add("class", POPULATION_CLASS_1);
+        boxes[1].add("id", POPULATION_ID_2);
+        boxes[1].add("class", POPULATION_CLASS_2);
+        boxes[2].add("id", POPULATION_ID_3);
+        boxes[2].add("class", POPULATION_CLASS_3);
+        PottsSeries series = makeSeriesForPopulation(boxes);
+        
+        assertEquals(3, series.populations.size());
+        assertNotNull(series.populations.get(POPULATION_ID_1));
+        assertNotNull(series.populations.get(POPULATION_ID_2));
+        assertNotNull(series.populations.get(POPULATION_ID_3));
+        assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
+        assertEquals(2, series.populations.get(POPULATION_ID_2).getInt("CODE"));
+        assertEquals(3, series.populations.get(POPULATION_ID_3).getInt("CODE"));
+        assertEquals(POPULATION_CLASS_1, series.populations.get(POPULATION_ID_1).get("CLASS"));
+        assertEquals(POPULATION_CLASS_2, series.populations.get(POPULATION_ID_2).get("CLASS"));
+        assertEquals(POPULATION_CLASS_3, series.populations.get(POPULATION_ID_3).get("CLASS"));
     }
     
     @Test

--- a/test/arcade/potts/sim/PottsSeriesTest.java
+++ b/test/arcade/potts/sim/PottsSeriesTest.java
@@ -20,30 +20,30 @@ import static arcade.potts.util.PottsEnums.Term;
 
 public class PottsSeriesTest {
     private static final double EPSILON = 1E-10;
-    
+
     private static final double DS = randomDoubleBetween(2, 10);
-    
+
     private static final double DT = randomDoubleBetween(0.5, 2);
-    
+
     private static final Box PARAMETERS = new Box();
-    
+
     private static final String[] REGION_IDS = new String[] {
             randomString().toUpperCase(),
             randomString().toUpperCase(),
     };
-    
+
     private static final String[] MODULE_IDS = new String[] {
             randomString().toLowerCase(),
             randomString().toLowerCase(),
     };
-    
+
     private static final String[] TERM_IDS = new String[] {
             randomString().toLowerCase(),
             randomString().toLowerCase(),
     };
-    
+
     private static final String TERM_ADHESION_PARAMETER = "adhesion" + TAG_SEPARATOR + "ADHESION";
-    
+
     private static final String[] POTTS_PARAMETER_NAMES = new String[] {
             TERM_ADHESION_PARAMETER,
             TERM_ADHESION_PARAMETER + "_" + REGION_IDS[0],
@@ -57,7 +57,7 @@ public class PottsSeriesTest {
             TERM_IDS[0] + TAG_SEPARATOR + "TERM_PARAMETER_11_" + REGION_IDS[1],
             TERM_IDS[1] + TAG_SEPARATOR + "TERM_PARAMETER_11_" + REGION_IDS[0],
     };
-    
+
     private static final String[] POTTS_PARAMETER_TERM_NAMES = new String[] {
             POTTS_PARAMETER_NAMES[6],
             POTTS_PARAMETER_NAMES[7],
@@ -65,7 +65,7 @@ public class PottsSeriesTest {
             POTTS_PARAMETER_NAMES[9],
             POTTS_PARAMETER_NAMES[10],
     };
-    
+
     private static final double[] POTTS_PARAMETER_VALUES = new double[] {
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
@@ -79,9 +79,9 @@ public class PottsSeriesTest {
             randomIntBetween(1, 100),
             randomIntBetween(1, 100),
     };
-    
+
     private static final int POTTS_PARAMETER_COUNT = POTTS_PARAMETER_NAMES.length;
-    
+
     private static final String[] POPULATION_PARAMETER_NAMES = new String[] {
             "POPULATION_PARAMETER_1",
             "POPULATION_PARAMETER_2",
@@ -93,7 +93,7 @@ public class PottsSeriesTest {
             REGION_IDS[1] + TAG_SEPARATOR + "POPULATION_PARAMETER_1",
             REGION_IDS[1] + TAG_SEPARATOR + "POPULATION_PARAMETER_2",
     };
-    
+
     private static final double[] POPULATION_PARAMETER_VALUES = new double[] {
             randomDoubleBetween(1, 100),
             randomDoubleBetween(1, 100),
@@ -105,35 +105,29 @@ public class PottsSeriesTest {
             randomDoubleBetween(1, 100),
             randomDoubleBetween(1, 100),
     };
-    
+
     private static final String POPULATION_ID_1 = randomString();
 
     private static final String POPULATION_CLASS_1 = randomString();
-    
+
     private static final String POPULATION_ID_2 = randomString();
 
     private static final String POPULATION_CLASS_2 = randomString();
-    
+
     private static final String POPULATION_ID_3 = randomString();
 
     private static final String POPULATION_CLASS_3 = randomString();
-    
+
     private static final String[] POPULATION_KEYS = new String[] {
             POPULATION_ID_1,
             POPULATION_ID_2,
             POPULATION_ID_3,
     };
 
-    private static final String[] POPULATION_CLASSES = new String[] {
-            POPULATION_CLASS_1,
-            POPULATION_CLASS_2,
-            POPULATION_CLASS_3,
-    };
-    
     private static final MiniBox POTTS = new MiniBox();
-    
+
     private static final MiniBox POPULATION = new MiniBox();
-    
+
     @BeforeClass
     public static void setupParameters() {
         // DEFAULTS
@@ -141,7 +135,7 @@ public class PottsSeriesTest {
         PARAMETERS.addTag("DT", "DEFAULT");
         PARAMETERS.addAtt("DS", "value", "" + DS);
         PARAMETERS.addAtt("DT", "value", "" + DT);
-        
+
         // POTTS
         for (int i = 0; i < POTTS_PARAMETER_COUNT; i++) {
             PARAMETERS.addTag(POTTS_PARAMETER_NAMES[i], "POTTS");
@@ -151,7 +145,7 @@ public class PottsSeriesTest {
         for (String key : potts.getKeys()) {
             POTTS.put(key, potts.get(key));
         }
-        
+
         // POPULATION
         for (int i = 0; i < POPULATION_PARAMETER_NAMES.length; i++) {
             PARAMETERS.addTag(POPULATION_PARAMETER_NAMES[i], "POPULATION");
@@ -162,19 +156,19 @@ public class PottsSeriesTest {
             POPULATION.put(key, population.get(key));
         }
     }
-    
+
     private HashMap<String, ArrayList<Box>> makeLists() {
         HashMap<String, ArrayList<Box>> setupLists = new HashMap<>();
-        
+
         ArrayList<Box> potts = new ArrayList<>();
         setupLists.put("potts", potts);
-        
+
         ArrayList<Box> populations = new ArrayList<>();
         setupLists.put("populations", populations);
-        
+
         return setupLists;
     }
-    
+
     private HashMap<String, MiniBox> makePopulations() {
         HashMap<String, MiniBox> populations = new HashMap<>();
         for (String population : POPULATION_KEYS) {
@@ -182,54 +176,55 @@ public class PottsSeriesTest {
         }
         return populations;
     }
-    
+
     @Test
     public void initialize_default_callsMethods() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.initialize(setupLists, PARAMETERS);
-        
+
         ArrayList<Box> potts = setupLists.get("potts");
         verify(series).updatePotts(eq(potts), any(MiniBox.class), any(MiniBox.class));
-        
+
         ArrayList<Box> populations = setupLists.get("populations");
         verify(series).updatePopulations(eq(populations), any(MiniBox.class), any(MiniBox.class));
-        
+
         ArrayList<Box> layers = setupLists.get("layers");
         verify(series).updateLayers(eq(layers), any(MiniBox.class), any(MiniBox.class));
-        
+
         ArrayList<Box> actions = setupLists.get("actions");
         verify(series).updateActions(eq(actions), any(MiniBox.class));
-        
+
         ArrayList<Box> components = setupLists.get("components");
         verify(series).updateComponents(eq(components), any(MiniBox.class));
     }
-    
+
     private PottsSeries makeSeriesForPotts(Box box) {
         return makeSeriesForPotts(box, new MiniBox());
     }
-    
+
     private PottsSeries makeSeriesForPotts(Box box, MiniBox conversion) {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         ArrayList<Box> potts = setupLists.get("potts");
         potts.add(box);
         series.populations = makePopulations();
-        
+
         try {
             Field dsField = Series.class.getDeclaredField("ds");
             dsField.setAccessible(true);
             dsField.setDouble(series, DS);
-            
+
             Field dtField = Series.class.getDeclaredField("dt");
             dtField.setAccessible(true);
             dtField.setDouble(series, DT);
-        } catch (Exception ignored) { }
-        
+        } catch (Exception ignored) {
+        }
+
         series.updatePotts(potts, POTTS, conversion);
         return series;
     }
-    
+
     @Test
     public void updatePotts_noSetting_createsBox() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
@@ -237,33 +232,33 @@ public class PottsSeriesTest {
         series.updatePotts(null, POTTS, new MiniBox());
         assertNotNull(series.potts);
     }
-    
+
     @Test
     public void updatePotts_noParameters_usesDefaults() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
-        
+
         for (String parameter : POTTS_PARAMETER_NAMES) {
             assertEquals(POTTS.get(parameter), box.get(parameter));
         }
     }
-    
+
     @Test
     public void updatePotts_givenParameters_updatesValues() {
         for (String pottsParameter1 : POTTS_PARAMETER_NAMES) {
             for (String pottsParameter2 : POTTS_PARAMETER_NAMES) {
                 Box potts = new Box();
-                
+
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(pottsParameter1, "value", "" + value);
                 potts.addTag(pottsParameter1, "PARAMETER");
                 potts.addAtt(pottsParameter2, "scale", "" + scale);
                 potts.addTag(pottsParameter2, "PARAMETER");
-                
+
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-                
+
                 for (String parameter : POTTS_PARAMETER_NAMES) {
                     double expected = POTTS.getDouble(parameter);
                     if (parameter.equals(pottsParameter1)) {
@@ -277,35 +272,35 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_noParameters_assignsTargets() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
-        
+
         for (String pop : POPULATION_KEYS) {
             for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                 assertEquals(POTTS.get(parameter), box.get(parameter + TARGET_SEPARATOR + pop));
             }
         }
     }
-    
+
     @Test
     public void updatePotts_givenParameters_assignsTargets() {
         for (String pottsParameter1 : POTTS_PARAMETER_TERM_NAMES) {
             for (String pottsParameter2 : POTTS_PARAMETER_TERM_NAMES) {
                 Box potts = new Box();
-                
+
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(pottsParameter1, "value", "" + value);
                 potts.addTag(pottsParameter1, "PARAMETER");
                 potts.addAtt(pottsParameter2, "scale", "" + scale);
                 potts.addTag(pottsParameter2, "PARAMETER");
-                
+
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-                
+
                 for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                     double expected = POTTS.getDouble(parameter);
                     if (parameter.equals(pottsParameter1)) {
@@ -314,7 +309,7 @@ public class PottsSeriesTest {
                     if (parameter.equals(pottsParameter2)) {
                         expected *= scale;
                     }
-                    
+
                     for (String pop : POPULATION_KEYS) {
                         assertEquals(expected, box.getDouble(parameter + TARGET_SEPARATOR + pop), EPSILON);
                     }
@@ -322,7 +317,7 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_givenPopulationParameters_updatesValues() {
         for (String pottsParameter1 : POTTS_PARAMETER_TERM_NAMES) {
@@ -336,21 +331,21 @@ public class PottsSeriesTest {
                         potts.addTag(pottsParameter1 + TARGET_SEPARATOR + pottsPop1, "PARAMETER");
                         potts.addAtt(pottsParameter2 + TARGET_SEPARATOR + pottsPop2, "scale", "" + scale);
                         potts.addTag(pottsParameter2 + TARGET_SEPARATOR + pottsPop2, "PARAMETER");
-                        
+
                         PottsSeries series = makeSeriesForPotts(potts);
                         MiniBox box = series.potts;
-                        
+
                         for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                             for (String pop : POPULATION_KEYS) {
                                 double expected = POTTS.getDouble(parameter);
-                                
+
                                 if (parameter.equals(pottsParameter1) && pop.equals(pottsPop1)) {
                                     expected = value;
                                 }
                                 if (parameter.equals(pottsParameter2) && pop.equals(pottsPop2)) {
                                     expected *= scale;
                                 }
-                                
+
                                 assertEquals(POTTS.getDouble(parameter), box.getDouble(parameter), EPSILON);
                                 assertEquals(expected, box.getDouble(parameter + TARGET_SEPARATOR + pop), EPSILON);
                             }
@@ -360,17 +355,17 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_withConversion_convertsValue() {
         MiniBox conversion = new MiniBox();
         String convertedParameter = POTTS_PARAMETER_NAMES[3];
         conversion.put(convertedParameter, "DT");
-        
+
         Box potts = new Box();
         PottsSeries series = makeSeriesForPotts(potts, conversion);
         MiniBox box = series.potts;
-        
+
         for (String parameter : POTTS_PARAMETER_NAMES) {
             double expected = POTTS.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -379,18 +374,18 @@ public class PottsSeriesTest {
             assertEquals(expected, box.getDouble(parameter), EPSILON);
         }
     }
-    
+
     @Test
     public void updatePotts_withTermConversion_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POTTS_PARAMETER_TERM_NAMES.length);
         String convertedParameter = POTTS_PARAMETER_TERM_NAMES[i];
         conversion.put(convertedParameter, "DT");
-        
+
         Box potts = new Box();
         PottsSeries series = makeSeriesForPotts(potts, conversion);
         MiniBox box = series.potts;
-        
+
         for (String pop : POPULATION_KEYS) {
             for (String parameter : POTTS_PARAMETER_TERM_NAMES) {
                 double expected = POTTS.getDouble(parameter);
@@ -401,37 +396,37 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_noAdhesion_usesDefaults() {
         PottsSeries series = makeSeriesForPotts(null);
         MiniBox box = series.potts;
         double adhesion = POTTS.getDouble(TERM_ADHESION_PARAMETER);
-        
+
         assertEquals(adhesion, box.getDouble(TERM_ADHESION_PARAMETER), EPSILON);
-        
+
         for (String source : POPULATION_KEYS) {
             String adhesionSource = TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + source;
             assertEquals(adhesion, box.getDouble(adhesionSource), EPSILON);
             assertEquals(adhesion, box.getDouble(adhesionSource + TARGET_SEPARATOR + "*"), EPSILON);
-            
+
             for (String target : POPULATION_KEYS) {
                 String adhesionTarget = adhesionSource + TARGET_SEPARATOR + target;
                 assertEquals(adhesion, box.getDouble(adhesionTarget), EPSILON);
             }
         }
     }
-    
+
     @Test
     public void updatePotts_givenAdhesion_updateValues() {
         String[] pops = new String[POPULATION_KEYS.length + 1];
         System.arraycopy(POPULATION_KEYS, 0, pops, 0, POPULATION_KEYS.length);
         pops[POPULATION_KEYS.length] = "*";
-        
+
         for (String pop1 : pops) {
             for (String pop2 : pops) {
                 Box potts = new Box();
-                
+
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 potts.addAtt(TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + pop1, "value", "" + value);
@@ -440,10 +435,10 @@ public class PottsSeriesTest {
                         + pop1 + TARGET_SEPARATOR + pop2, "scale", "" + scale);
                 potts.addTag(TERM_ADHESION_PARAMETER + TARGET_SEPARATOR
                         + pop1 + TARGET_SEPARATOR + pop2, "PARAMETER");
-                
+
                 PottsSeries series = makeSeriesForPotts(potts);
                 MiniBox box = series.potts;
-                
+
                 for (String source : POPULATION_KEYS) {
                     double expected1 = POTTS.getDouble(TERM_ADHESION_PARAMETER);
                     if (source.equals(pop1)) {
@@ -451,7 +446,7 @@ public class PottsSeriesTest {
                     }
                     String adhesionSource = TERM_ADHESION_PARAMETER + TARGET_SEPARATOR + source;
                     assertEquals(expected1, box.getDouble(adhesionSource), EPSILON);
-                    
+
                     for (String target : pops) {
                         double expected2 = expected1;
                         if (source.equals(pop1) && target.equals(pop2)) {
@@ -464,43 +459,43 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_withRegionsNoAdhesion_usesDefaults() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-        
+
         series.populations = makePopulations();
         String key = POPULATION_KEYS[randomIntBetween(0, POPULATION_KEYS.length)];
         MiniBox popBox = series.populations.get(key);
         popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[0], 0);
         popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[1], 0);
-        
+
         series.updatePotts(setupLists.get("potts"), POTTS, new MiniBox());
         MiniBox box = series.potts;
-        
+
         for (String source : REGION_IDS) {
             double adhesion = POTTS.getDouble(TERM_ADHESION_PARAMETER + "_" + source);
             assertEquals(adhesion, box.getDouble(TERM_ADHESION_PARAMETER + "_" + source), EPSILON);
-            
+
             String adhesionSource = TERM_ADHESION_PARAMETER + "_" + source + TARGET_SEPARATOR + key;
             assertEquals(adhesion, box.getDouble(adhesionSource), EPSILON);
-            
+
             for (String target : REGION_IDS) {
                 String adhesionTarget = adhesionSource + TARGET_SEPARATOR + target;
                 assertEquals(adhesion, box.getDouble(adhesionTarget), EPSILON);
             }
         }
     }
-    
+
     @Test
     public void updatePotts_withRegionsGivenAdhesion_updateValues() {
         String key = POPULATION_KEYS[randomIntBetween(0, POPULATION_KEYS.length)];
-        
+
         for (String region1 : REGION_IDS) {
             for (String region2 : REGION_IDS) {
                 Box potts = new Box();
-                
+
                 String adhesion = TERM_ADHESION_PARAMETER + "_" + region1;
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
@@ -510,19 +505,19 @@ public class PottsSeriesTest {
                         + key + TARGET_SEPARATOR + region2, "scale", "" + scale);
                 potts.addTag(adhesion + TARGET_SEPARATOR
                         + key + TARGET_SEPARATOR + region2, "PARAMETER");
-                
+
                 HashMap<String, ArrayList<Box>> setupLists = makeLists();
                 PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-                
+
                 series.populations = makePopulations();
                 MiniBox popBox = series.populations.get(key);
                 popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[0], 0);
                 popBox.put("(REGION)" + TAG_SEPARATOR + REGION_IDS[1], 0);
-                
+
                 setupLists.get("potts").add(potts);
                 series.updatePotts(setupLists.get("potts"), POTTS, new MiniBox());
                 MiniBox box = series.potts;
-                
+
                 for (String source : REGION_IDS) {
                     double expected1 = POTTS.getDouble(TERM_ADHESION_PARAMETER + "_" + source);
                     if (source.equals(region1)) {
@@ -530,7 +525,7 @@ public class PottsSeriesTest {
                     }
                     String adhesionSource = TERM_ADHESION_PARAMETER + "_" + source + TARGET_SEPARATOR + key;
                     assertEquals(expected1, box.getDouble(adhesionSource), EPSILON);
-                    
+
                     for (String target : REGION_IDS) {
                         double expected2 = expected1;
                         if (source.equals(region1) && target.equals(region2)) {
@@ -543,7 +538,7 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePotts_noTerms_createsList() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
@@ -551,63 +546,64 @@ public class PottsSeriesTest {
         series.updatePotts(null, POTTS, new MiniBox());
         assertNotNull(series.terms);
     }
-    
+
     @Test
     public void updatePotts_withTerms_createsList() {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.populations = new HashMap<>();
         ArrayList<Box> potts = setupLists.get("potts");
-        
+
         Box box = new Box();
         potts.add(box);
-        
+
         MersenneTwisterFast random = new MersenneTwisterFast();
         Term term1 = Term.random(random);
         Term term2 = Term.random(random);
-        
+
         box.addTag(term1.name(), "TERM");
         box.addTag(term2.name(), "TERM");
-        
+
         series.updatePotts(potts, POTTS, new MiniBox());
-        
+
         int n = (term1.equals(term2) ? 1 : 2);
         assertEquals(n, series.terms.size());
         assertTrue(series.terms.contains(term1));
         assertTrue(series.terms.contains(term2));
     }
-    
+
     private PottsSeries makeSeriesForPopulation(Box[] boxes) {
         return makeSeriesForPopulation(boxes, new MiniBox());
     }
-    
+
     private PottsSeries makeSeriesForPopulation(Box[] boxes, MiniBox conversion) {
         HashMap<String, ArrayList<Box>> setupLists = makeLists();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         ArrayList<Box> populations = setupLists.get("populations");
         populations.addAll(Arrays.asList(boxes));
-        
+
         try {
             Field dsField = Series.class.getDeclaredField("ds");
             dsField.setAccessible(true);
             dsField.setDouble(series, DS);
-            
+
             Field dtField = Series.class.getDeclaredField("dt");
             dtField.setAccessible(true);
             dtField.setDouble(series, DT);
-        } catch (Exception ignored) { }
-        
+        } catch (Exception ignored) {
+        }
+
         series.updatePopulations(populations, POPULATION, conversion);
         return series;
     }
-    
+
     @Test
     public void updatePopulation_noPopulations_createsMap() {
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
         series.updatePopulations(null, POPULATION, new MiniBox());
         assertEquals(0, series.populations.size());
     }
-    
+
     @Test
     public void updatePopulation_onePopulation_createsMap() {
         Box[] boxes = new Box[] { new Box() };
@@ -618,7 +614,7 @@ public class PottsSeriesTest {
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
     }
-    
+
     @Test
     public void updatePopulation_multiplePopulations_createsMap() {
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
@@ -626,7 +622,7 @@ public class PottsSeriesTest {
         boxes[1].add("id", POPULATION_ID_2);
         boxes[2].add("id", POPULATION_ID_3);
         PottsSeries series = makeSeriesForPopulation(boxes);
-        
+
         assertEquals(3, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertNotNull(series.populations.get(POPULATION_ID_2));
@@ -646,7 +642,7 @@ public class PottsSeriesTest {
         boxes[2].add("id", POPULATION_ID_3);
         boxes[2].add("class", POPULATION_CLASS_3);
         PottsSeries series = makeSeriesForPopulation(boxes);
-        
+
         assertEquals(3, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertNotNull(series.populations.get(POPULATION_ID_2));
@@ -658,130 +654,130 @@ public class PottsSeriesTest {
         assertEquals(POPULATION_CLASS_2, series.populations.get(POPULATION_ID_2).get("CLASS"));
         assertEquals(POPULATION_CLASS_3, series.populations.get(POPULATION_ID_3).get("CLASS"));
     }
-    
+
     @Test
     public void updatePopulation_noInit_setsZero() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
-        
+
         MiniBox box = series.populations.get(POPULATION_ID_1);
         assertEquals(0, box.getDouble("INIT"), EPSILON);
     }
-    
+
     @Test
     public void updatePopulation_givenValidInit_setsValue() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         int[] values = new int[] { 0, 10, 100 };
-        
+
         for (int i = 0; i < fractions.length; i++) {
             Box[] boxes = new Box[] { new Box() };
             boxes[0].add("id", POPULATION_ID_1);
             boxes[0].add("init", fractions[i]);
             PottsSeries series = makeSeriesForPopulation(boxes);
-            
+
             MiniBox box = series.populations.get(POPULATION_ID_1);
             assertEquals(values[i], box.getInt("INIT"));
         }
     }
-    
+
     @Test
     public void updatePopulation_givenInvalidInit_setsZero() {
         String[] fractions = new String[] { "1.1", "-1" };
-        
+
         for (String fraction : fractions) {
             Box[] boxes = new Box[] { new Box() };
             boxes[0].add("id", POPULATION_ID_1);
             boxes[0].add("init", fraction);
             PottsSeries series = makeSeriesForPopulation(boxes);
-            
+
             MiniBox box = series.populations.get(POPULATION_ID_1);
             assertEquals(0, box.getDouble("INIT"), EPSILON);
         }
     }
-    
+
     @Test
     public void updatePopulation_givenValidPadding_setsValue() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         String[] paddings = new String[] { "0", "10", "1E2" };
         int[] values = new int[] { 0, 10, 100 };
-        
+
         for (int i = 0; i < fractions.length; i++) {
             for (int j = 0; j < paddings.length; j++) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[0].add("init", fractions[i] + ":" + paddings[j]);
                 PottsSeries series = makeSeriesForPopulation(boxes);
-                
+
                 MiniBox box = series.populations.get(POPULATION_ID_1);
                 assertEquals(values[i], box.getInt("INIT"));
                 assertEquals(values[j], box.getInt("PADDING"));
             }
         }
     }
-    
+
     @Test
     public void updatePopulation_givenInvalidPadding_setsZero() {
         String[] fractions = new String[] { "0", "10", "1E2" };
         String[] paddings = new String[] { "1.1", "-1" };
         int[] values = new int[] { 0, 10, 100 };
-        
+
         for (int i = 0; i < fractions.length; i++) {
             for (String padding : paddings) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[0].add("init", fractions[i] + ":" + padding);
                 PottsSeries series = makeSeriesForPopulation(boxes);
-                
+
                 MiniBox box = series.populations.get(POPULATION_ID_1);
                 assertEquals(values[i], box.getInt("INIT"));
                 assertEquals(0, box.getInt("PADDING"));
             }
         }
     }
-    
+
     @Test
     public void updatePopulation_withRegions_setsTags() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         boxes[0].addTag(REGION_IDS[0], "REGION");
-        
+
         PottsSeries series = makeSeriesForPopulation(boxes);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-        
+
         assertEquals("", box.get("(REGION)" + TAG_SEPARATOR + REGION_IDS[0]));
         assertFalse(box.contains("(REGION)" + TAG_SEPARATOR + REGION_IDS[1]));
     }
-    
+
     @Test
     public void updatePopulation_noParametersOnePop_usesDefaults() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-        
+
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             assertEquals(POPULATION.get(parameter), box.get(parameter));
         }
     }
-    
+
     @Test
     public void updatePopulation_givenParametersOnePop_updatesValues() {
         for (String populationParameter1 : POPULATION_PARAMETER_NAMES) {
             for (String populationParameter2 : POPULATION_PARAMETER_NAMES) {
                 Box[] boxes = new Box[] { new Box() };
                 boxes[0].add("id", POPULATION_ID_1);
-                
+
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 boxes[0].addAtt(populationParameter1, "value", "" + value);
                 boxes[0].addTag(populationParameter1, "PARAMETER");
                 boxes[0].addAtt(populationParameter2, "scale", "" + scale);
                 boxes[0].addTag(populationParameter2, "PARAMETER");
-                
+
                 PottsSeries series = makeSeriesForPopulation(boxes);
                 MiniBox box = series.populations.get(POPULATION_ID_1);
-                
+
                 for (String parameter : POPULATION_PARAMETER_NAMES) {
                     double expected = POPULATION.getDouble(parameter);
                     if (parameter.equals(populationParameter1)) {
@@ -795,7 +791,7 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePopulation_noParametersMultiplePops_usesDefaults() {
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
@@ -806,14 +802,14 @@ public class PottsSeriesTest {
         MiniBox box1 = series.populations.get(POPULATION_ID_1);
         MiniBox box2 = series.populations.get(POPULATION_ID_2);
         MiniBox box3 = series.populations.get(POPULATION_ID_3);
-        
+
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             assertEquals(POPULATION.get(parameter), box1.get(parameter));
             assertEquals(POPULATION.get(parameter), box2.get(parameter));
             assertEquals(POPULATION.get(parameter), box3.get(parameter));
         }
     }
-    
+
     @Test
     public void updatePopulation_givenParametersMultiplePops_updatesValues() {
         for (String populationParameter1 : POPULATION_PARAMETER_NAMES) {
@@ -822,23 +818,23 @@ public class PottsSeriesTest {
                 boxes[0].add("id", POPULATION_ID_1);
                 boxes[1].add("id", POPULATION_ID_2);
                 boxes[2].add("id", POPULATION_ID_3);
-                
+
                 double value = randomDoubleBetween(1, 100);
                 double scale = randomDoubleBetween(1, 100);
                 boxes[1].addAtt(populationParameter1, "value", "" + value);
                 boxes[1].addTag(populationParameter1, "PARAMETER");
                 boxes[1].addAtt(populationParameter2, "scale", "" + scale);
                 boxes[1].addTag(populationParameter2, "PARAMETER");
-                
+
                 PottsSeries series = makeSeriesForPopulation(boxes);
                 MiniBox box1 = series.populations.get(POPULATION_ID_1);
                 MiniBox box2 = series.populations.get(POPULATION_ID_2);
                 MiniBox box3 = series.populations.get(POPULATION_ID_3);
-                
+
                 for (String parameter : POPULATION_PARAMETER_NAMES) {
                     assertEquals(POPULATION.get(parameter), box1.get(parameter));
                     assertEquals(POPULATION.get(parameter), box3.get(parameter));
-                    
+
                     double expected = POPULATION.getDouble(parameter);
                     if (parameter.equals(populationParameter1)) {
                         expected = value;
@@ -851,19 +847,19 @@ public class PottsSeriesTest {
             }
         }
     }
-    
+
     @Test
     public void updatePopulation_withConversionOnePop_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POPULATION_PARAMETER_NAMES.length);
         String convertedParameter = POPULATION_PARAMETER_NAMES[i];
         conversion.put(convertedParameter, "DS");
-        
+
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         PottsSeries series = makeSeriesForPopulation(boxes, conversion);
         MiniBox box = series.populations.get(POPULATION_ID_1);
-        
+
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             double expected = POPULATION.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -872,14 +868,14 @@ public class PottsSeriesTest {
             assertEquals(expected, box.getDouble(parameter), EPSILON);
         }
     }
-    
+
     @Test
     public void updatePopulation_withConversionMultiplePops_convertsValue() {
         MiniBox conversion = new MiniBox();
         int i = randomIntBetween(0, POPULATION_PARAMETER_NAMES.length);
         String convertedParameter = POPULATION_PARAMETER_NAMES[i];
         conversion.put(convertedParameter, "DS");
-        
+
         Box[] boxes = new Box[] { new Box(), new Box(), new Box() };
         boxes[0].add("id", POPULATION_ID_1);
         boxes[1].add("id", POPULATION_ID_2);
@@ -888,7 +884,7 @@ public class PottsSeriesTest {
         MiniBox box1 = series.populations.get(POPULATION_ID_1);
         MiniBox box2 = series.populations.get(POPULATION_ID_2);
         MiniBox box3 = series.populations.get(POPULATION_ID_3);
-        
+
         for (String parameter : POPULATION_PARAMETER_NAMES) {
             double expected = POPULATION.getDouble(parameter);
             if (parameter.equals(convertedParameter)) {
@@ -899,35 +895,37 @@ public class PottsSeriesTest {
             assertEquals(expected, box3.getDouble(parameter), EPSILON);
         }
     }
-    
+
     @Test
     public void getSimClass_given2D_returnsClass() {
         String className = PottsSimulation2D.class.getName();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-        
+
         try {
             Field field = Series.class.getDeclaredField("height");
             field.setAccessible(true);
             field.setInt(series, 1);
-        } catch (Exception ignored) { }
-        
+        } catch (Exception ignored) {
+        }
+
         assertEquals(className, series.getSimClass());
     }
-    
+
     @Test
     public void getSimClass_given3D_returnsClass() {
         String className = PottsSimulation3D.class.getName();
         PottsSeries series = mock(PottsSeries.class, CALLS_REAL_METHODS);
-        
+
         try {
             Field field = Series.class.getDeclaredField("height");
             field.setAccessible(true);
             field.setInt(series, 3);
-        } catch (Exception ignored) { }
-        
+        } catch (Exception ignored) {
+        }
+
         assertEquals(className, series.getSimClass());
     }
-    
+
     @Test
     public void getVisClass_allCases_returnsClass() {
         String className = PottsVisualization.class.getName();

--- a/test/arcade/potts/sim/PottsSeriesTest.java
+++ b/test/arcade/potts/sim/PottsSeriesTest.java
@@ -611,6 +611,18 @@ public class PottsSeriesTest {
         assertNotNull(series.populations.get(POPULATION_ID_1));
         assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
     }
+
+    @Test
+    public void updatePopulation_onePopulationWithClass_createsMap() {
+        Box[] boxes = new Box[] { new Box() };
+        boxes[0].add("id", POPULATION_ID_1);
+        boxes[0].add("class", POPULATION_CLASS_1);
+        PottsSeries series = makeSeriesForPopulation(boxes);
+        assertEquals(1, series.populations.size());
+        assertNotNull(series.populations.get(POPULATION_ID_1));
+        assertEquals(1, series.populations.get(POPULATION_ID_1).getInt("CODE"));
+        assertEquals(POPULATION_CLASS_1, series.populations.get(POPULATION_ID_1).get("CLASS"));
+    }
     
     @Test
     public void updatePopulation_multiplePopulations_createsMap() {

--- a/test/arcade/potts/sim/PottsSeriesTest.java
+++ b/test/arcade/potts/sim/PottsSeriesTest.java
@@ -606,7 +606,6 @@ public class PottsSeriesTest {
     public void updatePopulation_onePopulation_createsMap() {
         Box[] boxes = new Box[] { new Box() };
         boxes[0].add("id", POPULATION_ID_1);
-        boxes[0].add("class", POPULATION_CLASS_1);
         PottsSeries series = makeSeriesForPopulation(boxes);
         assertEquals(1, series.populations.size());
         assertNotNull(series.populations.get(POPULATION_ID_1));


### PR DESCRIPTION
- Adding functionality so a "CLASS" tag can be set in setup file and passed down to the population settings in PottsSeries. Followed pattern set in PatchSeries.
- Added one test to checks if CLASS value is correctly set
- Future plan is to check "CLASS" value in PottsCellContainer.java convert() to determine what type of cell should be constructed. This is the first step in that direction.