### PR TITLE
Remove apoptosis checkpoint for potts cells

### DIFF
--- a/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleApoptosisSimple.java
@@ -13,9 +13,6 @@ import static arcade.potts.util.PottsEnums.Region;
  */
 
 public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
-    /** Threshold for critical volume size checkpoint. */
-    static final double SIZE_CHECKPOINT = 0.95;
-    
     /** Target ratio of critical volume for early apoptosis size checkpoint. */
     static final double EARLY_SIZE_TARGET = 0.99;
     
@@ -96,17 +93,12 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
      * <p>
      * Cell continues to decrease in size due to cytoplasm blebbing and nuclear
      * fragmentation. Cell will complete apoptosis after completing
-     * {@code STEPS_LATE} steps at an average rate of {@code RATE_LATE} or if
-     * the total cell volume falls below a threshold of
-     * {@code APOPTOSIS_CHECKPOINT} times the critical size. Cell must be less
-     * than {@code LATE_SIZE_CHECKPOINT} times the critical size.
+     * {@code STEPS_LATE} steps at an average rate of {@code RATE_LATE}.
      */
     @Override
     void stepLate(MersenneTwisterFast random, Simulation sim) {
         // Decrease size of cell.
         cell.updateTarget(cytoBlebbingRate, LATE_SIZE_TARGET);
-        boolean sizeCheck = cell.getVolume() <= SIZE_CHECKPOINT
-                * LATE_SIZE_TARGET * cell.getCriticalVolume();
         
         // Decrease size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
@@ -116,7 +108,7 @@ public class PottsModuleApoptosisSimple extends PottsModuleApoptosis {
         // Check for completion of late phase.
         Poisson poisson = poissonFactory.createPoisson(rateLate, random);
         currentSteps += poisson.nextInt();
-        if (currentSteps >= stepsLate && sizeCheck) {
+        if (currentSteps >= stepsLate) {
             removeCell(sim);
             setPhase(Phase.APOPTOSED);
         }

--- a/test/arcade/potts/agent/module/PottsModuleApoptosisSimpleTest.java
+++ b/test/arcade/potts/agent/module/PottsModuleApoptosisSimpleTest.java
@@ -83,6 +83,7 @@ public class PottsModuleApoptosisSimpleTest {
         int steps = randomIntBetween(1, parameters.getInt("apoptosis/STEPS_EARLY"));
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
+        
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
         module.phase = Phase.APOPTOTIC_EARLY;
         module.currentSteps = module.stepsEarly - steps;
@@ -103,6 +104,7 @@ public class PottsModuleApoptosisSimpleTest {
     public void stepEarly_withoutTransition_maintainsPhase() {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
+        
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
         module.phase = Phase.APOPTOTIC_EARLY;
         module.currentSteps = module.stepsEarly;
@@ -157,13 +159,10 @@ public class PottsModuleApoptosisSimpleTest {
     }
     
     @Test
-    public void stepLate_withTransitionNotArrested_updatesPhase() {
+    public void stepLate_withTransition_updatesPhase() {
         int steps = randomIntBetween(1, parameters.getInt("apoptosis/STEPS_LATE"));
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
-        double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) - 1).when(cell).getVolume();
-        doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
         module.phase = Phase.APOPTOTIC_LATE;
@@ -184,65 +183,9 @@ public class PottsModuleApoptosisSimpleTest {
     }
     
     @Test
-    public void stepLate_withoutTransitionNotArrested_maintainsPhase() {
+    public void stepLate_withoutTransition_maintainsPhase() {
         PottsCell cell = mock(PottsCell.class);
         doReturn(parameters).when(cell).getParameters();
-        double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) - 1).when(cell).getVolume();
-        doReturn(volume).when(cell).getCriticalVolume();
-        
-        PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
-        module.phase = Phase.APOPTOTIC_LATE;
-        module.currentSteps = module.stepsLate;
-        doNothing().when(module).removeCell(simMock);
-        
-        Poisson poisson = mock(Poisson.class);
-        doReturn(-1).when(poisson).nextInt();
-        PoissonFactory poissonFactory = mock(PoissonFactory.class);
-        doReturn(poisson).when(poissonFactory).createPoisson(anyDouble(), eq(random));
-        module.poissonFactory = poissonFactory;
-        
-        module.stepLate(random, simMock);
-        
-        verify(module, never()).removeCell(simMock);
-        verify(module, never()).setPhase(any(Phase.class));
-        assertEquals(Phase.APOPTOTIC_LATE, module.phase);
-    }
-    
-    @Test
-    public void stepLate_withTransitionArrested_maintainsPhase() {
-        int steps = randomIntBetween(1, parameters.getInt("apoptosis/STEPS_LATE"));
-        PottsCell cell = mock(PottsCell.class);
-        doReturn(parameters).when(cell).getParameters();
-        double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) + 1).when(cell).getVolume();
-        doReturn(volume).when(cell).getCriticalVolume();
-        
-        PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
-        module.phase = Phase.APOPTOTIC_LATE;
-        module.currentSteps = module.stepsLate - steps;
-        doNothing().when(module).removeCell(simMock);
-        
-        Poisson poisson = mock(Poisson.class);
-        doReturn(steps).when(poisson).nextInt();
-        PoissonFactory poissonFactory = mock(PoissonFactory.class);
-        doReturn(poisson).when(poissonFactory).createPoisson(eq(module.rateLate), eq(random));
-        module.poissonFactory = poissonFactory;
-        
-        module.stepLate(random, simMock);
-        
-        verify(module, never()).removeCell(simMock);
-        verify(module, never()).setPhase(any(Phase.class));
-        assertEquals(Phase.APOPTOTIC_LATE, module.phase);
-    }
-    
-    @Test
-    public void stepLate_withoutTransitionArrested_maintainsPhase() {
-        PottsCell cell = mock(PottsCell.class);
-        doReturn(parameters).when(cell).getParameters();
-        double volume = randomDoubleBetween(0, 100);
-        doReturn((volume * SIZE_CHECKPOINT * LATE_SIZE_TARGET) + 1).when(cell).getVolume();
-        doReturn(volume).when(cell).getCriticalVolume();
         
         PottsModuleApoptosisSimple module = spy(new PottsModuleApoptosisSimple(cell));
         module.phase = Phase.APOPTOTIC_LATE;


### PR DESCRIPTION
Existing version of `PottsModuleApoptosisSimple` has a check that requires cells hit a minimum size before completing apoptosis, but (1) this leads to computational artifacts because the volume constraint is not exact and (2) is not biologically reasonable.

This change removes the size check so that completing apoptosis only depends on timing and removes the outdated tests.