### PR TITLE
Add support for initialization by percentage

### DIFF
--- a/src/arcade/patch/sim/PatchSeries.java
+++ b/src/arcade/patch/sim/PatchSeries.java
@@ -153,10 +153,18 @@ public final class PatchSeries extends Series {
             population.put("CLASS", populationClass);
             this.populations.put(id, population);
             
-            // Add population init if given. If not given or invalid, set to zero.
+            // Add population init if given. If value ends with percentage (%),
+            // use the PERCENT initialization type instead of the COUNT
+            // initialization type. If not given or invalid, set to zero.
+            String initType = "COUNT";
+            if (box.getValue("init") != null && box.getValue("init").endsWith("%")) {
+                box.add("init", box.getValue("init").replace("%", ""));
+                initType = "PERCENT";
+            }
             int init = (isValidNumber(box, "init")
-                    ? (int) Double.parseDouble(box.getValue("init")) : 0);
-            population.put("INIT", init);
+                    ? (int) Double.parseDouble(box.getValue("init")) : 0
+            );
+            population.put(initType, init);
             
             // Get default parameters and any parameter adjustments.
             Box parameters = box.filterBoxByTag("PARAMETER");

--- a/src/arcade/patch/sim/input/PatchInputBuilder.java
+++ b/src/arcade/patch/sim/input/PatchInputBuilder.java
@@ -203,17 +203,20 @@ public final class PatchInputBuilder extends InputBuilder {
         geometry = geometry.toUpperCase();
         
         PatchLocation location;
+        int totalPatches;
         
         if (geometry.equals("RECT")) {
             series.put("length", 4 * radiusBounds - 2);
             series.put("width", 4 * radiusBounds - 2);
             series.put("height", 2 * depthBounds - 1);
+            totalPatches = (2 * radius - 1) * (2 * radius - 1) * depth;
             CoordinateXYZ coordinate = new CoordinateXYZ(0, 0, 0);
             location = new PatchLocationRect(coordinate);
         } else if (geometry.equals("HEX")) {
             series.put("length", 6 * radiusBounds - 3);
             series.put("width", 4 * radiusBounds - 2);
             series.put("height", 2 * depthBounds - 1);
+            totalPatches = (1 + 3 * radius * (radius - 1)) * depth;
             CoordinateUVWZ coordinate = new CoordinateUVWZ(0, 0, 0, 0);
             location = new PatchLocationHex(coordinate);
         } else {
@@ -227,5 +230,6 @@ public final class PatchInputBuilder extends InputBuilder {
         patch.add("GRID_AREA", String.valueOf(location.getArea()));
         patch.add("LATTICE_VOLUME", String.valueOf(location.getVolume() / location.getMaximum()));
         patch.add("LATTICE_AREA", String.valueOf(location.getArea() / location.getMaximum()));
+        patch.add("TOTAL_PATCHES", String.valueOf(totalPatches));
     }
 }

--- a/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
@@ -1,0 +1,248 @@
+package arcade.patch.agent.cell;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import arcade.patch.sim.PatchSeries;
+import org.junit.Test;
+import sim.util.distribution.Normal;
+import sim.util.distribution.Uniform;
+import arcade.core.sim.Series;
+import arcade.core.util.MiniBox;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.*;
+
+public class PatchCellFactoryTest {
+    private static final double EPSILON = 1E-10;
+    
+    static PatchSeries createSeries(int[] init, String[] initTypes) {
+        PatchSeries series = mock(PatchSeries.class);
+        series.populations = new HashMap<>();
+        
+        for (int i = 0; i < init.length; i++) {
+            int pop = i + 1;
+            MiniBox box = new MiniBox();
+            box.put("CODE", pop);
+            box.put(initTypes[i], init[i]);
+            series.populations.put("pop" + pop, box);
+        }
+        
+        return series;
+    }
+    
+    static Normal makeNormalDistributionMock(double values) {
+        Normal distribution = mock(Normal.class);
+        doReturn(values).when(distribution).nextDouble();
+        return distribution;
+    }
+    
+    static Uniform makeUniformDistributionMock(int values) {
+        Uniform distribution = mock(Uniform.class);
+        doReturn(values).when(distribution).nextInt();
+        return distribution;
+    }
+    
+    @Test
+    public void createCells_noPopulation_createsEmpty() {
+        Series series = createSeries(new int[] { }, new String[] {});
+        
+        PatchCellFactory factory = new PatchCellFactory();
+        factory.createCells(series);
+        
+        assertEquals(0, factory.cells.size());
+        assertEquals(0, factory.popToIDs.size());
+    }
+    
+    @Test
+    public void createCells_onePopulationInitByCount_createsList() {
+        int count = randomIntBetween(1, 10);
+        PatchSeries series = createSeries(new int[] { count }, new String[] { "COUNT" });
+        
+        double volume = randomDoubleBetween(1, 10);
+        double height = randomDoubleBetween(1, 10);
+        int age = randomIntBetween(1, 100);
+        int divisions = randomIntBetween(1, 100);
+        double compression = randomDoubleBetween(1, 10);
+        
+        PatchCellFactory factory = new PatchCellFactory();
+        factory.popToIDs.put(1, new HashSet<>());
+        factory.popToCriticalVolumes.put(1, makeNormalDistributionMock(volume));
+        factory.popToCriticalHeights.put(1, makeNormalDistributionMock(height));
+        factory.popToAges.put(1, makeUniformDistributionMock(age));
+        factory.popToDivisions.put(1, divisions);
+        factory.popToCompression.put(1, compression);
+        factory.createCells(series);
+        
+        assertEquals(count, factory.cells.size());
+        assertEquals(count, factory.popToIDs.get(1).size());
+        
+        for (int i : factory.popToIDs.get(1)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volume, patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(age, patchCellContainer.age);
+            assertEquals(divisions, patchCellContainer.divisions);
+        }
+    }
+    
+    @Test
+    public void createCells_onePopulationInitByPercent_createsList() {
+        int totalPatches = randomIntBetween(10, 90);
+        int percent = randomIntBetween(1, 99);
+        int init = (int) Math.round(percent * totalPatches / 100.0);
+        PatchSeries series = createSeries(new int[] { percent }, new String[] { "PERCENT" });
+        
+        series.patch = new MiniBox();
+        series.patch.put("TOTAL_PATCHES", totalPatches);
+        
+        double volume = randomDoubleBetween(1, 10);
+        double height = randomDoubleBetween(1, 10);
+        int age = randomIntBetween(1, 100);
+        int divisions = randomIntBetween(1, 100);
+        double compression = randomDoubleBetween(1, 10);
+        
+        PatchCellFactory factory = new PatchCellFactory();
+        factory.popToIDs.put(1, new HashSet<>());
+        factory.popToCriticalVolumes.put(1, makeNormalDistributionMock(volume));
+        factory.popToCriticalHeights.put(1, makeNormalDistributionMock(height));
+        factory.popToAges.put(1, makeUniformDistributionMock(age));
+        factory.popToDivisions.put(1, divisions);
+        factory.popToCompression.put(1, compression);
+        factory.createCells(series);
+        
+        assertEquals(init, factory.cells.size());
+        assertEquals(init, factory.popToIDs.get(1).size());
+        
+        for (int i : factory.popToIDs.get(1)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volume, patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(age, patchCellContainer.age);
+            assertEquals(divisions, patchCellContainer.divisions);
+        }
+    }
+    
+    @Test
+    public void createCells_onePopulationInitByPercentOver100_createsList() {
+        int totalPatches = randomIntBetween(10, 90);
+        int percent = 200;
+        PatchSeries series = createSeries(new int[] { percent }, new String[] { "PERCENT" });
+        
+        series.patch = new MiniBox();
+        series.patch.put("TOTAL_PATCHES", totalPatches);
+        
+        double volume = randomDoubleBetween(1, 10);
+        double height = randomDoubleBetween(1, 10);
+        int age = randomIntBetween(1, 100);
+        int divisions = randomIntBetween(1, 100);
+        double compression = randomDoubleBetween(1, 10);
+        
+        PatchCellFactory factory = new PatchCellFactory();
+        factory.popToIDs.put(1, new HashSet<>());
+        factory.popToCriticalVolumes.put(1, makeNormalDistributionMock(volume));
+        factory.popToCriticalHeights.put(1, makeNormalDistributionMock(height));
+        factory.popToAges.put(1, makeUniformDistributionMock(age));
+        factory.popToDivisions.put(1, divisions);
+        factory.popToCompression.put(1, compression);
+        factory.createCells(series);
+        
+        assertEquals(totalPatches, factory.cells.size());
+        assertEquals(totalPatches, factory.popToIDs.get(1).size());
+        
+        for (int i : factory.popToIDs.get(1)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volume, patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(age, patchCellContainer.age);
+            assertEquals(divisions, patchCellContainer.divisions);
+        }
+    }
+    
+    @Test
+    public void createCells_multiplePopulationsMixedInit_createsList() {
+        int totalPatches = randomIntBetween(10, 90);
+        int count1 = randomIntBetween(1, 10);
+        int percent2 = randomIntBetween(40, 50);
+        int init2 = (int) Math.round(percent2 * totalPatches / 100.0);
+        int count3 = randomIntBetween(1, 10);
+        PatchSeries series = createSeries(new int[] { count1, percent2, count3 }, new String[] {"COUNT", "PERCENT", "COUNT"});
+        
+        series.patch = new MiniBox();
+        series.patch.put("TOTAL_PATCHES", totalPatches);
+        
+        double[] volumes = new double[] {
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+        };
+        double[] heights = new double[] {
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+        };
+        int[] ages = new int[] {
+                randomIntBetween(1, 100),
+                randomIntBetween(1, 100),
+                randomIntBetween(1, 100),
+        };
+        int[] divisions = new int[] {
+                randomIntBetween(1, 100),
+                randomIntBetween(1, 100),
+                randomIntBetween(1, 100),
+        };
+        double[] compressions = new double[] {
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+                randomDoubleBetween(1, 10),
+        };
+        
+        PatchCellFactory factory = new PatchCellFactory();
+        factory.popToIDs.put(1, new HashSet<>());
+        factory.popToIDs.put(2, new HashSet<>());
+        factory.popToIDs.put(3, new HashSet<>());
+        factory.popToCriticalVolumes.put(1, makeNormalDistributionMock(volumes[0]));
+        factory.popToCriticalVolumes.put(2, makeNormalDistributionMock(volumes[1]));
+        factory.popToCriticalVolumes.put(3, makeNormalDistributionMock(volumes[2]));
+        factory.popToCriticalHeights.put(1, makeNormalDistributionMock(heights[0]));
+        factory.popToCriticalHeights.put(2, makeNormalDistributionMock(heights[1]));
+        factory.popToCriticalHeights.put(3, makeNormalDistributionMock(heights[2]));
+        factory.popToAges.put(1, makeUniformDistributionMock(ages[0]));
+        factory.popToAges.put(2, makeUniformDistributionMock(ages[1]));
+        factory.popToAges.put(3, makeUniformDistributionMock(ages[2]));
+        factory.popToDivisions.put(1, divisions[0]);
+        factory.popToDivisions.put(2, divisions[1]);
+        factory.popToDivisions.put(3, divisions[2]);
+        factory.popToCompression.put(1, compressions[0]);
+        factory.popToCompression.put(2, compressions[1]);
+        factory.popToCompression.put(3, compressions[2]);
+        factory.createCells(series);
+        factory.createCells(series);
+        
+        assertEquals(count1 + init2 + count3, factory.cells.size());
+        assertEquals(count1, factory.popToIDs.get(1).size());
+        assertEquals(init2, factory.popToIDs.get(2).size());
+        assertEquals(count3, factory.popToIDs.get(3).size());
+        
+        for (int i : factory.popToIDs.get(1)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volumes[0], patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(heights[0] + compressions[0], patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(ages[0], patchCellContainer.age);
+            assertEquals(divisions[0], patchCellContainer.divisions);
+        }
+        for (int i : factory.popToIDs.get(2)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volumes[1], patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(heights[1] + compressions[1], patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(ages[1], patchCellContainer.age);
+            assertEquals(divisions[1], patchCellContainer.divisions);
+        }
+        for (int i : factory.popToIDs.get(3)) {
+            PatchCellContainer patchCellContainer = factory.cells.get(i);
+            assertEquals(volumes[2], patchCellContainer.criticalVolume, EPSILON);
+            assertEquals(heights[2] + compressions[2], patchCellContainer.criticalHeight, EPSILON);
+            assertEquals(ages[2], patchCellContainer.age);
+            assertEquals(divisions[2], patchCellContainer.divisions);
+        }
+    }
+}

--- a/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
@@ -2,12 +2,12 @@ package arcade.patch.agent.cell;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import arcade.patch.sim.PatchSeries;
 import org.junit.Test;
 import sim.util.distribution.Normal;
 import sim.util.distribution.Uniform;
 import arcade.core.sim.Series;
 import arcade.core.util.MiniBox;
+import arcade.patch.sim.PatchSeries;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
@@ -165,7 +165,8 @@ public class PatchCellFactoryTest {
         int percent2 = randomIntBetween(40, 50);
         int init2 = (int) Math.round(percent2 * totalPatches / 100.0);
         int count3 = randomIntBetween(1, 10);
-        PatchSeries series = createSeries(new int[] { count1, percent2, count3 }, new String[] {"COUNT", "PERCENT", "COUNT"});
+        PatchSeries series = createSeries(new int[] { count1, percent2, count3 },
+                new String[] {"COUNT", "PERCENT", "COUNT"});
         
         series.patch = new MiniBox();
         series.patch.put("TOTAL_PATCHES", totalPatches);

--- a/test/arcade/patch/sim/PatchSeriesTest.java
+++ b/test/arcade/patch/sim/PatchSeriesTest.java
@@ -238,22 +238,53 @@ public class PatchSeriesTest {
         PatchSeries series = makeSeriesForPopulation(boxes);
         
         MiniBox box = series.populations.get(POPULATION_ID_1);
-        assertEquals(0, box.getDouble("INIT"), EPSILON);
+        assertEquals(0, box.getDouble("COUNT"), EPSILON);
     }
     
     @Test
-    public void updatePopulation_givenInit_setsValue() {
-        String[] fractions = new String[] { "0", "10", "1E2" };
-        int[] values = new int[] { 0, 10, 100 };
+    public void updatePopulation_givenInvalidInit_setsValue() {
+        String[] invalid = new String[] { "", "a", "5%5", "-2", "5.5%" };
         
-        for (int i = 0; i < fractions.length; i++) {
+        for (int i = 0; i < invalid.length; i++) {
             Box[] boxes = new Box[] { new Box() };
             boxes[0].add("id", POPULATION_ID_1);
-            boxes[0].add("init", fractions[i]);
+            boxes[0].add("init", invalid[i]);
             PatchSeries series = makeSeriesForPopulation(boxes);
             
             MiniBox box = series.populations.get(POPULATION_ID_1);
-            assertEquals(values[i], box.getInt("INIT"));
+            assertEquals(0, box.getInt("COUNT"));
+        }
+    }
+    
+    @Test
+    public void updatePopulation_givenNumberInit_setsValue() {
+        String[] numbers = new String[] { "0", "10", "1E2" };
+        int[] values = new int[] { 0, 10, 100 };
+        
+        for (int i = 0; i < numbers.length; i++) {
+            Box[] boxes = new Box[] { new Box() };
+            boxes[0].add("id", POPULATION_ID_1);
+            boxes[0].add("init", numbers[i]);
+            PatchSeries series = makeSeriesForPopulation(boxes);
+            
+            MiniBox box = series.populations.get(POPULATION_ID_1);
+            assertEquals(values[i], box.getInt("COUNT"));
+        }
+    }
+    
+    @Test
+    public void updatePopulation_givenPercentInit_setsValue() {
+        String[] percents = new String[] { "0%", "50%", "100%" };
+        int[] values = new int[] { 0, 50, 100 };
+        
+        for (int i = 0; i < percents.length; i++) {
+            Box[] boxes = new Box[] { new Box() };
+            boxes[0].add("id", POPULATION_ID_1);
+            boxes[0].add("init", percents[i]);
+            PatchSeries series = makeSeriesForPopulation(boxes);
+            
+            MiniBox box = series.populations.get(POPULATION_ID_1);
+            assertEquals(values[i], box.getInt("PERCENT"));
         }
     }
     


### PR DESCRIPTION
Resolves #49 

Updates `patch` initialization to support integer percentages:

- Update `PatchSeries` to parse percent initialization (+ tests) 
- Update `PatchCellFactory` to generate number of cell containers using either `COUNT` or `PERCENT` initialization types (+ tests)
- Update `PatchInputBuilder` to calculate total number of available patches based on radius and geometry