### PR TITLE
replace instance of wildcard import of Module to prevent clash in Java 9

### DIFF
--- a/test/arcade/potts/agent/cell/PottsCellTest.java
+++ b/test/arcade/potts/agent/cell/PottsCellTest.java
@@ -9,7 +9,7 @@ import sim.engine.Schedule;
 import sim.engine.Stoppable;
 import ec.util.MersenneTwisterFast;
 import arcade.core.agent.cell.CellState;
-import arcade.core.agent.module.*;
+import arcade.core.agent.module.Module;
 import arcade.core.env.location.*;
 import arcade.core.util.MiniBox;
 import arcade.potts.agent.module.PottsModule;


### PR DESCRIPTION
Java 9 adds a `java.lang.Module` that leads to an issue when trying to reference a class that is also named Module due to ambiguous reference. This change removes the wildcard import. 