### PR TITLE
Update cell make method to return container

### DIFF
--- a/src/arcade/core/agent/cell/Cell.java
+++ b/src/arcade/core/agent/cell/Cell.java
@@ -135,15 +135,14 @@ public interface Cell extends Steppable {
     void stop();
 
     /**
-     * Creates a new cell.
+     * Creates a new cell container.
      *
      * @param id the new cell ID
      * @param state the new cell state
-     * @param location the new cell location
      * @param random the random number generator
      * @return the new {@code Cell} object
      */
-    Cell make(int id, CellState state, Location location, MersenneTwisterFast random);
+    CellContainer make(int id, CellState state, MersenneTwisterFast random);
 
     /**
      * Schedules the cell in the simulation.

--- a/src/arcade/core/sim/Simulation.java
+++ b/src/arcade/core/sim/Simulation.java
@@ -6,10 +6,12 @@ import com.google.gson.reflect.TypeToken;
 import sim.engine.Schedule;
 import arcade.core.agent.action.Action;
 import arcade.core.agent.cell.CellContainer;
+import arcade.core.agent.cell.CellFactory;
 import arcade.core.env.component.Component;
 import arcade.core.env.grid.Grid;
 import arcade.core.env.lattice.Lattice;
 import arcade.core.env.location.LocationContainer;
+import arcade.core.env.location.LocationFactory;
 
 /**
  * A {@code Simulation} sets up agents and environments for a simulation.
@@ -74,6 +76,20 @@ public interface Simulation {
      * @return a list of {@link LocationContainer} objects
      */
     ArrayList<LocationContainer> getLocations();
+
+    /**
+     * Gets the initialized {@link CellFactory} for the simulation.
+     *
+     * @return the {@link CellFactory} object
+     */
+    CellFactory getCellFactory();
+
+    /**
+     * Gets the initialized {@link LocationFactory} for the simulation.
+     *
+     * @return the {@link LocationFactory} object
+     */
+    LocationFactory getLocationFactory();
 
     /**
      * Gets the {@link Grid} object.

--- a/src/arcade/patch/agent/cell/PatchCellCancer.java
+++ b/src/arcade/patch/agent/cell/PatchCellCancer.java
@@ -77,18 +77,15 @@ public class PatchCellCancer extends PatchCellTissue {
     }
 
     @Override
-    public PatchCell make(
-            int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
+    public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
         divisions--;
-        return new PatchCellTissue(
+        return new PatchCellContainer(
                 newID,
                 id,
                 pop,
-                newState,
                 age,
                 divisions,
-                newLocation,
-                parameters,
+                newState,
                 volume,
                 height,
                 criticalVolume,

--- a/src/arcade/patch/agent/cell/PatchCellCancerStem.java
+++ b/src/arcade/patch/agent/cell/PatchCellCancerStem.java
@@ -82,34 +82,18 @@ public class PatchCellCancerStem extends PatchCellCancer {
      * <p>Cells have a certain probability of producing another cancer stem cell.
      */
     @Override
-    public PatchCell make(
-            int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
-        return random.nextDouble() < symmetricFraction
-                ? new PatchCellCancerStem(
-                        newID,
-                        id,
-                        pop,
-                        newState,
-                        age,
-                        divisions,
-                        newLocation,
-                        parameters,
-                        volume,
-                        height,
-                        criticalVolume,
-                        criticalHeight)
-                : new PatchCellCancer(
-                        newID,
-                        id,
-                        pop,
-                        newState,
-                        age,
-                        divisions - 1,
-                        newLocation,
-                        parameters,
-                        volume,
-                        height,
-                        criticalVolume,
-                        criticalHeight);
+    public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
+        int newDivisons = random.nextDouble() < symmetricFraction ? divisions : divisions - 1;
+        return new PatchCellContainer(
+                newID,
+                id,
+                pop,
+                age,
+                newDivisons,
+                newState,
+                volume,
+                height,
+                criticalVolume,
+                criticalHeight);
     }
 }

--- a/src/arcade/patch/agent/cell/PatchCellRandom.java
+++ b/src/arcade/patch/agent/cell/PatchCellRandom.java
@@ -62,18 +62,15 @@ public class PatchCellRandom extends PatchCell {
     }
 
     @Override
-    public PatchCell make(
-            int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
+    public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
         divisions--;
-        return new PatchCellRandom(
+        return new PatchCellContainer(
                 newID,
                 id,
                 pop,
-                newState,
                 age,
                 divisions,
-                newLocation,
-                parameters,
+                newState,
                 volume,
                 height,
                 criticalVolume,

--- a/src/arcade/patch/agent/cell/PatchCellTissue.java
+++ b/src/arcade/patch/agent/cell/PatchCellTissue.java
@@ -52,18 +52,15 @@ public class PatchCellTissue extends PatchCell {
     }
 
     @Override
-    public PatchCell make(
-            int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
+    public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
         divisions--;
-        return new PatchCellTissue(
+        return new PatchCellContainer(
                 newID,
                 id,
                 pop,
-                newState,
                 age,
                 divisions,
-                newLocation,
-                parameters,
+                newState,
                 volume,
                 height,
                 criticalVolume,

--- a/src/arcade/patch/agent/module/PatchModuleProliferation.java
+++ b/src/arcade/patch/agent/module/PatchModuleProliferation.java
@@ -2,6 +2,7 @@ package arcade.patch.agent.module;
 
 import sim.util.Bag;
 import ec.util.MersenneTwisterFast;
+import arcade.core.agent.cell.CellContainer;
 import arcade.core.sim.Simulation;
 import arcade.core.util.MiniBox;
 import arcade.patch.agent.cell.PatchCell;
@@ -84,8 +85,9 @@ public class PatchModuleProliferation extends PatchModule {
 
                     // Create and schedule new cell.
                     int newID = sim.getID();
+                    CellContainer newContainer = cell.make(newID, State.UNDEFINED, random);
                     PatchCell newCell =
-                            (PatchCell) cell.make(newID, State.UNDEFINED, newLocation, random);
+                            (PatchCell) newContainer.convert(sim.getCellFactory(), newLocation);
                     sim.getGrid().addObject(newCell, newLocation);
                     newCell.schedule(sim.getSchedule());
 

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -8,11 +8,13 @@ import sim.engine.SimState;
 import arcade.core.agent.action.Action;
 import arcade.core.agent.cell.Cell;
 import arcade.core.agent.cell.CellContainer;
+import arcade.core.agent.cell.CellFactory;
 import arcade.core.env.component.Component;
 import arcade.core.env.grid.Grid;
 import arcade.core.env.lattice.Lattice;
 import arcade.core.env.location.Location;
 import arcade.core.env.location.LocationContainer;
+import arcade.core.env.location.LocationFactory;
 import arcade.core.sim.Series;
 import arcade.core.sim.Simulation;
 import arcade.core.util.MiniBox;
@@ -113,6 +115,16 @@ public abstract class PatchSimulation extends SimState implements Simulation {
         }
 
         return locationContainers;
+    }
+
+    @Override
+    public final CellFactory getCellFactory() {
+        return cellFactory;
+    }
+
+    @Override
+    public final LocationFactory getLocationFactory() {
+        return locationFactory;
     }
 
     @Override

--- a/src/arcade/potts/agent/cell/PottsCellStem.java
+++ b/src/arcade/potts/agent/cell/PottsCellStem.java
@@ -68,19 +68,18 @@ public final class PottsCellStem extends PottsCell {
     }
 
     @Override
-    public PottsCell make(
-            int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
+    public PottsCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
         divisions++;
-        return new PottsCellStem(
+        return new PottsCellContainer(
                 newID,
                 id,
                 pop,
-                newState,
                 age,
                 divisions,
-                newLocation,
-                hasRegions,
-                parameters,
+                newState,
+                null,
+                0,
+                null,
                 criticalVolume,
                 criticalHeight,
                 criticalRegionVolumes,

--- a/src/arcade/potts/agent/module/PottsModuleProliferation.java
+++ b/src/arcade/potts/agent/module/PottsModuleProliferation.java
@@ -1,6 +1,7 @@
 package arcade.potts.agent.module;
 
 import ec.util.MersenneTwisterFast;
+import arcade.core.agent.cell.CellContainer;
 import arcade.core.env.location.Location;
 import arcade.core.sim.Simulation;
 import arcade.potts.agent.cell.PottsCell;
@@ -101,7 +102,8 @@ public abstract class PottsModuleProliferation extends PottsModule {
 
         // Create and schedule new cell.
         int newID = sim.getID();
-        PottsCell newCell = (PottsCell) cell.make(newID, State.PROLIFERATIVE, newLocation, random);
+        CellContainer newContainer = cell.make(newID, State.PROLIFERATIVE, random);
+        PottsCell newCell = (PottsCell) newContainer.convert(sim.getCellFactory(), newLocation);
         sim.getGrid().addObject(newCell, null);
         potts.register(newCell);
         newCell.reset(potts.ids, potts.regions);

--- a/src/arcade/potts/sim/PottsSimulation.java
+++ b/src/arcade/potts/sim/PottsSimulation.java
@@ -7,11 +7,13 @@ import sim.engine.SimState;
 import arcade.core.agent.action.Action;
 import arcade.core.agent.cell.Cell;
 import arcade.core.agent.cell.CellContainer;
+import arcade.core.agent.cell.CellFactory;
 import arcade.core.env.component.Component;
 import arcade.core.env.grid.Grid;
 import arcade.core.env.lattice.Lattice;
 import arcade.core.env.location.Location;
 import arcade.core.env.location.LocationContainer;
+import arcade.core.env.location.LocationFactory;
 import arcade.core.sim.Series;
 import arcade.core.sim.Simulation;
 import arcade.core.util.MiniBox;
@@ -101,6 +103,16 @@ public abstract class PottsSimulation extends SimState implements Simulation {
         }
 
         return locationContainers;
+    }
+
+    @Override
+    public final CellFactory getCellFactory() {
+        return cellFactory;
+    }
+
+    @Override
+    public final LocationFactory getLocationFactory() {
+        return locationFactory;
     }
 
     @Override

--- a/test/arcade/core/sim/SeriesTest.java
+++ b/test/arcade/core/sim/SeriesTest.java
@@ -11,10 +11,12 @@ import sim.engine.SimState;
 import sim.engine.Steppable;
 import arcade.core.agent.action.Action;
 import arcade.core.agent.cell.CellContainer;
+import arcade.core.agent.cell.CellFactory;
 import arcade.core.env.component.Component;
 import arcade.core.env.grid.Grid;
 import arcade.core.env.lattice.Lattice;
 import arcade.core.env.location.LocationContainer;
+import arcade.core.env.location.LocationFactory;
 import arcade.core.util.Box;
 import arcade.core.util.MiniBox;
 import arcade.core.vis.*;
@@ -137,6 +139,16 @@ public class SeriesTest {
 
         @Override
         public ArrayList<LocationContainer> getLocations() {
+            return null;
+        }
+
+        @Override
+        public CellFactory getCellFactory() {
+            return null;
+        }
+
+        @Override
+        public LocationFactory getLocationFactory() {
             return null;
         }
 

--- a/test/arcade/patch/agent/cell/PatchCellRandomTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellRandomTest.java
@@ -2,12 +2,9 @@ package arcade.patch.agent.cell;
 
 import org.junit.jupiter.api.Test;
 import ec.util.MersenneTwisterFast;
-import arcade.core.env.location.*;
 import arcade.core.util.MiniBox;
 import arcade.patch.agent.module.PatchModule;
 import arcade.patch.agent.process.PatchProcessMetabolism;
-import arcade.patch.agent.process.PatchProcessMetabolismMedium;
-import arcade.patch.agent.process.PatchProcessSignalingSimple;
 import arcade.patch.env.location.PatchLocation;
 import arcade.patch.sim.PatchSimulation;
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,24 +41,16 @@ public class PatchCellRandomTest {
     static MiniBox parametersMock = new MiniBox();
 
     @Test
-    public void make_called_setsFields() {
+    public void make_called_createsContainer() {
         double volume = randomDoubleBetween(10, 100);
         double height = randomDoubleBetween(10, 100);
         double criticalVolume = randomDoubleBetween(10, 100);
         double criticalHeight = randomDoubleBetween(10, 100);
-        MiniBox parameters = new MiniBox();
-
-        String metabolism = "medium";
-        String signaling = "simple";
-        parameters.put("(PROCESS)/" + Domain.METABOLISM, metabolism);
-        parameters.put("(PROCESS)/" + Domain.SIGNALING, signaling);
 
         State state1 = State.QUIESCENT;
         State state2 = State.PROLIFERATIVE;
-        Location location1 = mock(PatchLocation.class);
-        Location location2 = mock(PatchLocation.class);
 
-        PatchCellRandom cell1 =
+        PatchCellRandom cell =
                 new PatchCellRandom(
                         cellID,
                         cellParent,
@@ -69,28 +58,25 @@ public class PatchCellRandomTest {
                         state1,
                         cellAge,
                         cellDivisions,
-                        location1,
-                        parameters,
+                        locationMock,
+                        parametersMock,
                         volume,
                         height,
                         criticalVolume,
                         criticalHeight);
-        PatchCellRandom cell2 = (PatchCellRandom) cell1.make(cellID + 1, state2, location2, null);
+        PatchCellContainer container = cell.make(cellID + 1, state2, null);
 
-        assertEquals(cellID + 1, cell2.id);
-        assertEquals(cellID, cell2.parent);
-        assertEquals(cellPop, cell2.pop);
-        assertEquals(cellAge, cell2.getAge());
-        assertEquals(cellDivisions - 1, cell1.getDivisions());
-        assertEquals(cellDivisions - 1, cell2.getDivisions());
-        assertEquals(location2, cell2.getLocation());
-        assertEquals(cell2.parameters, parameters);
-        assertEquals(volume, cell2.getVolume(), EPSILON);
-        assertEquals(height, cell2.getHeight(), EPSILON);
-        assertEquals(criticalVolume, cell2.getCriticalVolume(), EPSILON);
-        assertEquals(criticalHeight, cell2.getCriticalHeight(), EPSILON);
-        assertTrue(cell2.getProcess(Domain.METABOLISM) instanceof PatchProcessMetabolismMedium);
-        assertTrue(cell2.getProcess(Domain.SIGNALING) instanceof PatchProcessSignalingSimple);
+        assertEquals(cellID + 1, container.id);
+        assertEquals(cellID, container.parent);
+        assertEquals(cellPop, container.pop);
+        assertEquals(cellAge, container.age);
+        assertEquals(cellDivisions - 1, container.divisions);
+        assertEquals(cellDivisions - 1, container.divisions);
+        assertEquals(state2, container.state);
+        assertEquals(volume, container.volume, EPSILON);
+        assertEquals(height, container.height, EPSILON);
+        assertEquals(criticalVolume, container.criticalVolume, EPSILON);
+        assertEquals(criticalHeight, container.criticalHeight, EPSILON);
     }
 
     @Test

--- a/test/arcade/potts/agent/cell/PottsCellStemTest.java
+++ b/test/arcade/potts/agent/cell/PottsCellStemTest.java
@@ -1,7 +1,6 @@
 package arcade.potts.agent.cell;
 
 import java.util.EnumMap;
-import java.util.EnumSet;
 import org.junit.jupiter.api.Test;
 import arcade.core.env.location.*;
 import arcade.core.util.MiniBox;
@@ -130,14 +129,11 @@ public class PottsCellStemTest {
     }
 
     @Test
-    public void make_noRegions_setsFields() {
+    public void make_noRegions_createsContainer() {
         double criticalVolume = randomDoubleBetween(10, 100);
         double criticalHeight = randomDoubleBetween(10, 100);
-        MiniBox parameters = mock(MiniBox.class);
-        Location location1 = mock(PottsLocation.class);
-        Location location2 = mock(PottsLocation.class);
 
-        PottsCellStem cell1 =
+        PottsCellStem cell =
                 new PottsCellStem(
                         cellID,
                         cellParent,
@@ -145,36 +141,35 @@ public class PottsCellStemTest {
                         cellState,
                         cellAge,
                         cellDivisions,
-                        location1,
+                        locationMock,
                         false,
-                        parameters,
+                        parametersMock,
                         criticalVolume,
                         criticalHeight,
                         null,
                         null);
-        PottsCellStem cell2 =
-                (PottsCellStem) cell1.make(cellID + 1, State.QUIESCENT, location2, null);
+        PottsCellContainer container = cell.make(cellID + 1, State.QUIESCENT, null);
 
-        assertEquals(cellID + 1, cell2.id);
-        assertEquals(cellID, cell2.parent);
-        assertEquals(cellPop, cell2.pop);
-        assertEquals(cellAge, cell2.getAge());
-        assertEquals(cellDivisions + 1, cell1.getDivisions());
-        assertEquals(cellDivisions + 1, cell2.getDivisions());
-        assertFalse(cell2.hasRegions());
-        assertEquals(location2, cell2.getLocation());
-        assertEquals(cell2.parameters, parameters);
-        assertEquals(criticalVolume, cell2.getCriticalVolume(), EPSILON);
-        assertEquals(criticalHeight, cell2.getCriticalHeight(), EPSILON);
+        assertEquals(cellID + 1, container.id);
+        assertEquals(cellID, container.parent);
+        assertEquals(cellPop, container.pop);
+        assertEquals(cellAge, container.age);
+        assertEquals(cellDivisions + 1, cell.getDivisions());
+        assertEquals(cellDivisions + 1, container.divisions);
+        assertEquals(State.QUIESCENT, container.state);
+        assertNull(container.phase);
+        assertEquals(0, container.voxels);
+        assertNull(container.regionVoxels);
+        assertEquals(criticalVolume, container.criticalVolume, EPSILON);
+        assertEquals(criticalHeight, container.criticalHeight, EPSILON);
+        assertNull(container.criticalRegionVolumes);
+        assertNull(container.criticalRegionHeights);
     }
 
     @Test
-    public void make_hasRegions_setsFields() {
+    public void make_hasRegions_createsContainer() {
         double criticalVolume = randomDoubleBetween(10, 100);
         double criticalHeight = randomDoubleBetween(10, 100);
-        MiniBox parameters = mock(MiniBox.class);
-        PottsLocation location1 = mock(PottsLocation.class);
-        PottsLocation location2 = mock(PottsLocation.class);
         EnumMap<Region, Double> criticalVolumesRegion = new EnumMap<>(Region.class);
         EnumMap<Region, Double> criticalHeightsRegion = new EnumMap<>(Region.class);
 
@@ -183,11 +178,7 @@ public class PottsCellStemTest {
             criticalHeightsRegion.put(region, randomDoubleBetween(10, 100));
         }
 
-        EnumSet<Region> allRegions = EnumSet.allOf(Region.class);
-        doReturn(allRegions).when(location1).getRegions();
-        doReturn(allRegions).when(location2).getRegions();
-
-        PottsCellStem cell1 =
+        PottsCellStem cell =
                 new PottsCellStem(
                         cellID,
                         cellParent,
@@ -195,32 +186,36 @@ public class PottsCellStemTest {
                         cellState,
                         cellAge,
                         cellDivisions,
-                        location1,
+                        locationMock,
                         true,
-                        parameters,
+                        parametersMock,
                         criticalVolume,
                         criticalHeight,
                         criticalVolumesRegion,
                         criticalHeightsRegion);
-        PottsCellStem cell2 =
-                (PottsCellStem) cell1.make(cellID + 1, State.QUIESCENT, location2, null);
+        PottsCellContainer container = cell.make(cellID + 1, State.QUIESCENT, null);
 
-        assertEquals(cellID + 1, cell2.id);
-        assertEquals(cellID, cell2.parent);
-        assertEquals(cellPop, cell2.pop);
-        assertEquals(cellAge, cell2.getAge());
-        assertEquals(cellDivisions + 1, cell1.getDivisions());
-        assertEquals(cellDivisions + 1, cell2.getDivisions());
-        assertTrue(cell2.hasRegions());
-        assertEquals(location2, cell2.getLocation());
-        assertEquals(cell2.parameters, parameters);
-        assertEquals(criticalVolume, cell2.getCriticalVolume(), EPSILON);
-        assertEquals(criticalHeight, cell2.getCriticalHeight(), EPSILON);
+        assertEquals(cellID + 1, container.id);
+        assertEquals(cellID, container.parent);
+        assertEquals(cellPop, container.pop);
+        assertEquals(cellAge, container.age);
+        assertEquals(cellDivisions + 1, cell.getDivisions());
+        assertEquals(cellDivisions + 1, container.divisions);
+        assertEquals(State.QUIESCENT, container.state);
+        assertNull(container.phase);
+        assertEquals(0, container.voxels);
+        assertNull(container.regionVoxels);
+        assertEquals(criticalVolume, container.criticalVolume, EPSILON);
+        assertEquals(criticalHeight, container.criticalHeight, EPSILON);
         for (Region region : Region.values()) {
             assertEquals(
-                    criticalVolumesRegion.get(region), cell2.getCriticalVolume(region), EPSILON);
+                    criticalVolumesRegion.get(region),
+                    container.criticalRegionVolumes.get(region),
+                    EPSILON);
             assertEquals(
-                    criticalHeightsRegion.get(region), cell2.getCriticalHeight(region), EPSILON);
+                    criticalHeightsRegion.get(region),
+                    container.criticalRegionHeights.get(region),
+                    EPSILON);
         }
     }
 }

--- a/test/arcade/potts/agent/cell/PottsCellTest.java
+++ b/test/arcade/potts/agent/cell/PottsCellTest.java
@@ -108,18 +108,17 @@ public class PottsCellTest {
         }
 
         @Override
-        public PottsCellMock make(
-                int newID, CellState newState, Location newLocation, MersenneTwisterFast random) {
-            return new PottsCellMock(
+        public PottsCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
+            return new PottsCellContainer(
                     newID,
                     id,
                     pop,
-                    newState,
                     age,
                     divisions,
-                    newLocation,
-                    hasRegions,
-                    parameters,
+                    newState,
+                    null,
+                    0,
+                    null,
                     criticalVolume,
                     criticalHeight,
                     criticalRegionVolumes,

--- a/test/arcade/potts/agent/module/PottsModuleProliferationTest.java
+++ b/test/arcade/potts/agent/module/PottsModuleProliferationTest.java
@@ -3,10 +3,12 @@ package arcade.potts.agent.module;
 import org.junit.jupiter.api.Test;
 import sim.engine.Schedule;
 import ec.util.MersenneTwisterFast;
+import arcade.core.agent.cell.CellFactory;
 import arcade.core.env.grid.Grid;
 import arcade.core.sim.Simulation;
 import arcade.core.util.MiniBox;
 import arcade.potts.agent.cell.PottsCell;
+import arcade.potts.agent.cell.PottsCellContainer;
 import arcade.potts.env.location.PottsLocation;
 import arcade.potts.sim.Potts;
 import arcade.potts.sim.PottsSimulation;
@@ -150,6 +152,7 @@ public class PottsModuleProliferationTest {
         Potts potts = mock(Potts.class);
         Grid grid = mock(Grid.class);
         PottsSimulation sim = mock(PottsSimulation.class);
+        CellFactory cellFactory = mock(CellFactory.class);
         Schedule schedule = mock(Schedule.class);
 
         int id = randomIntBetween(1, 100);
@@ -157,16 +160,17 @@ public class PottsModuleProliferationTest {
         doReturn(id).when(sim).getID();
         doReturn(grid).when(sim).getGrid();
         doReturn(schedule).when(sim).getSchedule();
+        doReturn(cellFactory).when(sim).getCellFactory();
 
         potts.ids = new int[][][] {{{}}};
         potts.regions = new int[][][] {{{}}};
 
         PottsLocation newLocation = mock(PottsLocation.class);
+        PottsCellContainer newContainer = mock(PottsCellContainer.class);
         PottsCell newCell = mock(PottsCell.class);
 
-        doReturn(newCell)
-                .when(cell)
-                .make(eq(id), any(State.class), eq(newLocation), eq(randomMock));
+        doReturn(newContainer).when(cell).make(eq(id), any(State.class), eq(randomMock));
+        doReturn(newCell).when(newContainer).convert(eq(cellFactory), eq(newLocation));
         doReturn(location).when(cell).getLocation();
         doReturn(newLocation).when(location).split(randomMock);
         doNothing().when(cell).reset(any(), any());


### PR DESCRIPTION
Update the `Cell` interface `make` method to return a `CellContainer` rather than an actual cell instance. This lets us reuse the `CellContainer` convert method to create cell instances.

Part 1 (of 3) in refactor to enable more flexibility for switching between populations.