### PR TITLE
Add support for different patch initialization schemes

### DIFF
--- a/src/arcade/patch/env/location/PatchLocationFactory.java
+++ b/src/arcade/patch/env/location/PatchLocationFactory.java
@@ -1,6 +1,7 @@
 package arcade.patch.env.location;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import ec.util.MersenneTwisterFast;
@@ -63,7 +64,18 @@ public abstract class PatchLocationFactory implements LocationFactory {
         // Get all valid coordinates.
         ArrayList<Coordinate> coordinates = getCoordinates(patchSeries.radius, patchSeries.depth);
         Utilities.shuffleList(coordinates, random);
-        coordinates.sort(Comparator.comparingDouble(Coordinate::calculateDistance));
+
+        // Sort coordinates by distance if initialization scheme is not random.
+        // For "outward" initialization, locations with distances closer to the
+        // center are filled first. For "inward" initialization, locations with
+        // distances further from the center are filled first.
+        String initialization = patchSeries.patch.get("INITIALIZATION");
+        if (!initialization.equalsIgnoreCase("random")) {
+            coordinates.sort(Comparator.comparingDouble(Coordinate::calculateDistance));
+            if (initialization.equalsIgnoreCase("inward")) {
+                Collections.reverse(coordinates);
+            }
+        }
 
         // Create containers for each coordinate.
         int id = 1;

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -5,6 +5,7 @@
 
     <!-- default parameters for patch -->
     <patch id="GEOMETRY" value="hex" description="Patch geometry (hex or rect)" />
+    <patch id="INITIALIZATION" value="outward" description="Patch initialization (inward or outward or random)" />
 
     <!-- POPULATIONS ======================================================= -->
 


### PR DESCRIPTION
Resolves #48 

Adds a new `patch` parameter called `INITIALIZATION` that support different initialization schemes. Current behavior (`outward`) is still the default if `INITIALIZATION` is not specified:

```xml
<patch>
    <patch.parameter id="INITIALIZATION" value="(outward|inward|random)" />
</patch>
```