### PR TITLE
Hot fix: passing in initial glucose as a parameter value

### DIFF
--- a/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
@@ -59,6 +59,9 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
     /** Rate of glucose uptake [fmol glucose/um<sup>2</sup> cell/min/M glucose]. */
     private final double glucoseUptakeRate;
 
+    /** Initial cell internal glucose concentration [fmol]. */
+    private final double initGluc;
+
     /**
      * Creates a complex metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -74,17 +77,13 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
      *   <li>{@code LACTATE_RATE} = rate of lactate production
      *   <li>{@code AUTOPHAGY_RATE} = rate of autophagy
      *   <li>{@code GLUCOSE_UPTAKE_RATE} = rate of glucose uptake
+     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with
      */
     public PatchProcessMetabolismComplex(PatchCell cell) {
         super(cell);
-
-        // Initial internal concentrations.
-        intAmts = new double[2];
-        intAmts[GLUCOSE] = extAmts[GLUCOSE];
-        intAmts[PYRUVATE] = extAmts[GLUCOSE] * PYRU_PER_GLUC;
 
         // Mapping for internal concentration access.
         String[] intNames = new String[2];
@@ -101,6 +100,12 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
         lactateRate = parameters.getDouble("metabolism/LACTATE_RATE");
         autophagyRate = parameters.getDouble("metabolism/AUTOPHAGY_RATE");
         glucoseUptakeRate = parameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE");
+        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+
+        // Initial internal concentrations.
+        intAmts = new double[2];
+        intAmts[GLUCOSE] = initGluc;
+        intAmts[PYRUVATE] = extAmts[GLUCOSE] * PYRU_PER_GLUC;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
@@ -102,7 +102,7 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
         intAmts = new double[2];
         intAmts[GLUCOSE] =
                 parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
-        intAmts[PYRUVATE] = extAmts[GLUCOSE] * PYRU_PER_GLUC;
+        intAmts[PYRUVATE] = intAmts[GLUCOSE] * PYRU_PER_GLUC;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
@@ -59,9 +59,6 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
     /** Rate of glucose uptake [fmol glucose/um<sup>2</sup> cell/min/M glucose]. */
     private final double glucoseUptakeRate;
 
-    /** Initial cell internal glucose concentration [fmol]. */
-    private final double initGluc;
-
     /**
      * Creates a complex metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -100,11 +97,10 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
         lactateRate = parameters.getDouble("metabolism/LACTATE_RATE");
         autophagyRate = parameters.getDouble("metabolism/AUTOPHAGY_RATE");
         glucoseUptakeRate = parameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE");
-        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
 
         // Initial internal concentrations.
         intAmts = new double[2];
-        intAmts[GLUCOSE] = initGluc;
+        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
         intAmts[PYRUVATE] = extAmts[GLUCOSE] * PYRU_PER_GLUC;
     }
 

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismComplex.java
@@ -100,7 +100,8 @@ public class PatchProcessMetabolismComplex extends PatchProcessMetabolism {
 
         // Initial internal concentrations.
         intAmts = new double[2];
-        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+        intAmts[GLUCOSE] =
+                parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
         intAmts[PYRUVATE] = extAmts[GLUCOSE] * PYRU_PER_GLUC;
     }
 

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
@@ -83,7 +83,8 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+        intAmts[GLUCOSE] =
+                parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
@@ -47,6 +47,9 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
     /** Rate of ATP production [fmol ATP/um<sup>3</sup>/min/M glucose]. */
     private final double atpProductionRate;
 
+    /** Initial cell internal glucose concentration [fmol]. */
+    private final double initGluc;
+
     /**
      * Creates a medium metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -60,16 +63,13 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
      *   <li>{@code MINIMUM_MASS_FRACTION} = minimum viable cell mass fraction
      *   <li>{@code AUTOPHAGY_RATE} = rate of autophagy
      *   <li>{@code ATP_PRODUCTION_RATE} = rate of ATP production
+     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with
      */
     public PatchProcessMetabolismMedium(PatchCell cell) {
         super(cell);
-
-        // Initial internal concentrations.
-        intAmts = new double[1];
-        intAmts[GLUCOSE] = extAmts[GLUCOSE];
 
         // Mapping for internal concentration access.
         String[] intNames = new String[1];
@@ -83,6 +83,11 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
         minimumMassFraction = parameters.getDouble("metabolism/MINIMUM_MASS_FRACTION");
         autophagyRate = parameters.getDouble("metabolism/AUTOPHAGY_RATE");
         atpProductionRate = parameters.getDouble("metabolism/ATP_PRODUCTION_RATE");
+        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+
+        // Initial internal concentrations.
+        intAmts = new double[1];
+        intAmts[GLUCOSE] = initGluc;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
@@ -47,9 +47,6 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
     /** Rate of ATP production [fmol ATP/um<sup>3</sup>/min/M glucose]. */
     private final double atpProductionRate;
 
-    /** Initial cell internal glucose concentration [fmol]. */
-    private final double initGluc;
-
     /**
      * Creates a medium metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -83,11 +80,10 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
         minimumMassFraction = parameters.getDouble("metabolism/MINIMUM_MASS_FRACTION");
         autophagyRate = parameters.getDouble("metabolism/AUTOPHAGY_RATE");
         atpProductionRate = parameters.getDouble("metabolism/ATP_PRODUCTION_RATE");
-        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = initGluc;
+        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismMedium.java
@@ -61,7 +61,6 @@ public class PatchProcessMetabolismMedium extends PatchProcessMetabolism {
      *   <li>{@code AUTOPHAGY_RATE} = rate of autophagy
      *   <li>{@code ATP_PRODUCTION_RATE} = rate of ATP production
      *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
-     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
@@ -58,7 +58,6 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
      * <ul>
      *   <li>{@code CELL_VOLUME} = cell volume
      *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
-     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
@@ -76,7 +76,8 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+        intAmts[GLUCOSE] =
+                parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
@@ -48,9 +48,6 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
     /** Average cell volume [um<sup>3</sup>]. */
     private final double averageCellVolume;
 
-    /** Initial cell internal glucose concentration [fmol]. */
-    private final double initGluc;
-
     /**
      * Creates a random metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -76,11 +73,10 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
         // Set loaded parameters.
         Parameters parameters = cell.getParameters();
         averageCellVolume = parameters.getDouble("CELL_VOLUME");
-        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = initGluc;
+        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismRandom.java
@@ -48,6 +48,9 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
     /** Average cell volume [um<sup>3</sup>]. */
     private final double averageCellVolume;
 
+    /** Initial cell internal glucose concentration [fmol]. */
+    private final double initGluc;
+
     /**
      * Creates a random metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -57,16 +60,13 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
      *
      * <ul>
      *   <li>{@code CELL_VOLUME} = cell volume
+     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with
      */
     public PatchProcessMetabolismRandom(PatchCell cell) {
         super(cell);
-
-        // Initial internal concentrations.
-        intAmts = new double[1];
-        intAmts[GLUCOSE] = extAmts[GLUCOSE];
 
         // Mapping for internal concentration access.
         String[] intNames = new String[1];
@@ -76,6 +76,11 @@ public class PatchProcessMetabolismRandom extends PatchProcessMetabolism {
         // Set loaded parameters.
         Parameters parameters = cell.getParameters();
         averageCellVolume = parameters.getDouble("CELL_VOLUME");
+        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+
+        // Initial internal concentrations.
+        intAmts = new double[1];
+        intAmts[GLUCOSE] = initGluc;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
@@ -69,7 +69,8 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
+        intAmts[GLUCOSE] =
+                parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
@@ -33,6 +33,9 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
     /** Constant volume growth rate [um<sup>3</sup>/min]. */
     private final double volumeGrowthRate;
 
+    /** Initial cell internal glucose concentration [fmol]. */
+    private final double initGluc;
+
     /**
      * Creates a simple metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -46,16 +49,13 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
      *   <li>{@code CONSTANT_GLUCOSE_UPTAKE_RATE} = constant glucose uptake rate
      *   <li>{@code CONSTANT_ATP_PRODUCTION_RATE} = constant ATP production rate
      *   <li>{@code CONSTANT_VOLUME_GROWTH_RATE} = constant volume growth rate
+     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with
      */
     public PatchProcessMetabolismSimple(PatchCell cell) {
         super(cell);
-
-        // Initial internal concentrations.
-        intAmts = new double[1];
-        intAmts[GLUCOSE] = extAmts[GLUCOSE];
 
         // Mapping for internal concentration access.
         String[] intNames = new String[1];
@@ -69,6 +69,11 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
         glucoseUptakeRate = parameters.getDouble("metabolism/CONSTANT_GLUCOSE_UPTAKE_RATE");
         atpProductionRate = parameters.getDouble("metabolism/CONSTANT_ATP_PRODUCTION_RATE");
         volumeGrowthRate = parameters.getDouble("metabolism/CONSTANT_VOLUME_GROWTH_RATE");
+        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+
+        // Initial internal concentrations.
+        intAmts = new double[1];
+        intAmts[GLUCOSE] = initGluc;
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
@@ -33,9 +33,6 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
     /** Constant volume growth rate [um<sup>3</sup>/min]. */
     private final double volumeGrowthRate;
 
-    /** Initial cell internal glucose concentration [fmol]. */
-    private final double initGluc;
-
     /**
      * Creates a simple metabolism {@code Process} for the given {@link PatchCell}.
      *
@@ -69,11 +66,10 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
         glucoseUptakeRate = parameters.getDouble("metabolism/CONSTANT_GLUCOSE_UPTAKE_RATE");
         atpProductionRate = parameters.getDouble("metabolism/CONSTANT_ATP_PRODUCTION_RATE");
         volumeGrowthRate = parameters.getDouble("metabolism/CONSTANT_VOLUME_GROWTH_RATE");
-        initGluc = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = initGluc;
+        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismSimple.java
@@ -69,7 +69,7 @@ public class PatchProcessMetabolismSimple extends PatchProcessMetabolism {
 
         // Initial internal concentrations.
         intAmts = new double[1];
-        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION");
+        intAmts[GLUCOSE] = parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
     }
 
     @Override

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -48,7 +48,7 @@
     <population.process process="metabolism" id="CONSTANT_GLUCOSE_UPTAKE_RATE" value="929.88" unit="fmol glucose/min/M glucose" description="constant glucose uptake rate" />
     <population.process process="metabolism" id="CONSTANT_ATP_PRODUCTION_RATE" value="4.9817" unit="fmol ATP/cell/min" description="constant ATP production rate" />
     <population.process process="metabolism" id="CONSTANT_VOLUME_GROWTH_RATE" value="2.819" unit="um^3/min" description="constant volume growth rate"/>
-    <population.process process="metabolism" id="INITIAL_GLUCOSE_CONCENTRATION" value="0" unit="fmol" description="initial cell internal glucose concentration"/>
+    <population.process process="metabolism" id="INITIAL_GLUCOSE_CONCENTRATION" value="0.17" unit="fmol/um^3" description="initial cell internal glucose concentration"/>
 
     <!-- signaling process parameters -->
     <population.process process="signaling" id="MIGRATORY_THRESHOLD" value="10" description="threshold fold change in PLCg for migration" />

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -48,6 +48,7 @@
     <population.process process="metabolism" id="CONSTANT_GLUCOSE_UPTAKE_RATE" value="929.88" unit="fmol glucose/min/M glucose" description="constant glucose uptake rate" />
     <population.process process="metabolism" id="CONSTANT_ATP_PRODUCTION_RATE" value="4.9817" unit="fmol ATP/cell/min" description="constant ATP production rate" />
     <population.process process="metabolism" id="CONSTANT_VOLUME_GROWTH_RATE" value="2.819" unit="um^3/min" description="constant volume growth rate"/>
+    <population.process process="metabolism" id="INITIAL_GLUCOSE_CONCENTRATION" value="0" unit="fmol" description="initial cell internal glucose concentration"/>
 
     <!-- signaling process parameters -->
     <population.process process="signaling" id="MIGRATORY_THRESHOLD" value="10" description="threshold fold change in PLCg for migration" />

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -48,7 +48,7 @@
     <population.process process="metabolism" id="CONSTANT_GLUCOSE_UPTAKE_RATE" value="929.88" unit="fmol glucose/min/M glucose" description="constant glucose uptake rate" />
     <population.process process="metabolism" id="CONSTANT_ATP_PRODUCTION_RATE" value="4.9817" unit="fmol ATP/cell/min" description="constant ATP production rate" />
     <population.process process="metabolism" id="CONSTANT_VOLUME_GROWTH_RATE" value="2.819" unit="um^3/min" description="constant volume growth rate"/>
-    <population.process process="metabolism" id="INITIAL_GLUCOSE_CONCENTRATION" value="0.17" unit="fmol/um^3" description="initial cell internal glucose concentration"/>
+    <population.process process="metabolism" id="INITIAL_GLUCOSE_CONCENTRATION" value="0.005" unit="fmol/um^3" description="initial cell internal glucose concentration"/>
 
     <!-- signaling process parameters -->
     <population.process process="signaling" id="MIGRATORY_THRESHOLD" value="10" description="threshold fold change in PLCg for migration" />


### PR DESCRIPTION
1. Adding volume multiplier to other three PatchMetabolism classes (random, complex, medium)
2. Changing intAmts of pyruvate to be based on intAmts on glucose as opposed to extAmts 