### PR TITLE
Add CHANGELOG for previous releases and release workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,20 +40,6 @@ jobs:
           _badges
           _coverage
 
-    - name: Extract project version
-      run: |
-        echo "VERSION=$(grep -oP 'version = "\K([0-9\.]+)(?=")' build.gradle)" >> $GITHUB_ENV
-
-    - name: Generate version badge
-      uses: knightdave/anybadge-action@v1.1.0
-      with:
-        file: docs/_badges/version.svg
-        label: version
-        value: v${{ env.VERSION }}
-        color: teal
-        template: docs/_badges/template.svg
-        overwrite: true
-
     - name: Generate license badge
       uses: knightdave/anybadge-action@v1.1.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,105 @@
+name: publish
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  publish:
+    if: ${{ (startsWith(github.event.pull_request.head.ref, 'release/')) && (github.event.pull_request.merged == true) }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: read
+
+    steps:
+
+    - name: Checkout the repo
+      uses: actions/checkout@v4
+
+    - name: Extract version from branch name
+      run: |
+        BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+        VERSION=${BRANCH_NAME#release/}
+        echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Build changelog
+      id: build_changelog
+      uses: mikepenz/release-changelog-builder-action@v3.4.0
+      with:
+        configurationJson: |
+          {
+            "categories": [
+              {
+                "title": "## 🚀 Features",
+                "labels": ["type: feature"],
+                "exclude_labels": ["package: patch", "package: potts"]
+              },
+              {
+                "title": "### Features: `patch`",
+                "labels": ["type: feature", "package: patch"],
+                "exclude_labels": ["package: potts"],
+                "exhaustive": true
+              },
+              {
+                "title": "### Features: `potts`",
+                "labels": ["type: feature", "package: potts"],
+                "exclude_labels": ["package: patch"],
+                "exhaustive": true
+              },
+              {
+                "title": "## 🐛 Bug fixes",
+                "labels": ["type: bug"]
+              },
+              {
+                "title": "## 🧪 Tests",
+                "labels": ["type: test"]
+              },
+              {
+                "title": "## 📓 Documentation",
+                "labels": ["type: docs"]
+              },
+              {
+                "title": "## 📁 Admin",
+                "labels": ["type: admin"]
+              }
+            ],
+            "template": "#{{CHANGELOG}}---\n\n**Full Changelog**: https://github.com/${{ github.repository }}/compare/#{{FROM_TAG}}...${{ env.RELEASE_VERSION }}\n",
+            "pr_template": "- #{{TITLE}} by @#{{AUTHOR}} in #{{URL}}"
+          }
+        toTag: ${{ github.event.pull_request.merge_commit_sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create release
+      uses: ncipollo/release-action@v1
+      with:
+        commit: ${{ github.event.pull_request.merge_commit_sha }}
+        tag: ${{ env.RELEASE_VERSION }}
+        name: ${{ env.RELEASE_VERSION }}
+        body: ${{ steps.build_changelog.outputs.changelog }}
+
+    - name: Generate version badge
+      if: success()
+      uses: knightdave/anybadge-action@v1.1.0
+      with:
+        file: docs/_badges/version.svg
+        label: version
+        value: ${{ env.RELEASE_VERSION }}
+        color: teal
+        template: docs/_badges/template.svg
+        overwrite: true
+
+    - name: Publish badge
+      if: success()
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: gh-pages
+        folder: docs/_badges
+        target-folder: _badges
+        clean: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: release
+
+on:
+  push:
+    branches:
+      - 'release/*'
+
+jobs:
+  check:
+    outputs:
+      status: ${{ steps.current_pr.outputs.pr_found }}
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+
+    - name: Get current PR
+      uses: 8BitJonny/gh-get-current-pr@3.0.0
+      id: current_pr
+
+  release:
+    needs: check
+
+    if: needs.check.outputs.status == 'false'
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Get app token
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+
+    - name: Checkout the repo
+      uses: actions/checkout@v3
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Extract version from branch name
+      run: |
+        BRANCH_NAME="${{ github.event.push.ref }}"
+        VERSION=${GITHUB_REF##*/}
+        echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Get current date
+      run: |
+        echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+    - name: Build changelog
+      id: build_changelog
+      uses: mikepenz/release-changelog-builder-action@v4
+      with:
+        configurationJson: |
+          {
+            "categories": [
+              {
+                "title": "### Features",
+                "labels": ["type: feature"],
+                "exclude_labels": ["package: patch", "package: potts"]
+              },
+              {
+                "title": "#### Features: `patch`",
+                "labels": ["type: feature", "package: patch"],
+                "exclude_labels": ["package: potts"],
+                "exhaustive": true
+              },
+              {
+                "title": "#### Features: `potts`",
+                "labels": ["type: feature", "package: potts"],
+                "exclude_labels": ["package: patch"],
+                "exhaustive": true
+              },
+              {
+                "title": "### Bug fixes",
+                "labels": ["type: bug"]
+              },
+              {
+                "title": "### Tests",
+                "labels": ["type: test"]
+              },
+              {
+                "title": "### Documentation",
+                "labels": ["type: docs"]
+              },
+              {
+                "title": "### Admin",
+                "labels": ["type: admin"]
+              }
+            ],
+            "template": "# [${{ env.RELEASE_VERSION }}](https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_VERSION }}) - ${{ env.CURRENT_DATE }}\n\n> Compare with [#{{FROM_TAG}}](https://github.com/${{ github.repository }}/compare/#{{FROM_TAG}}...${{ env.RELEASE_VERSION }})\n\n#{{CHANGELOG}}",
+            "pr_template": "- #{{TITLE}} by [@#{{AUTHOR}}](https://github.com/#{{AUTHOR}}) in [##{{NUMBER}}](#{{URL}})"
+          }
+        toTag: ${{ github.sha }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update changelog
+      run: |
+        printf "%s%s\n" "${{ steps.build_changelog.outputs.changelog }}" "$(cat CHANGELOG.md)" > CHANGELOG.md
+
+    - uses: EndBug/add-and-commit@v9
+      with:
+          add: "CHANGELOG.md"
+          author_name: bagheri-lab-bot[bot]
+          author_email: bagheri-lab-bot[bot]@users.noreply.github.com
+          message: "Update CHANGELOG.md for ${{ env.RELEASE_VERSION }}"
+          default_author: github_actor
+          push: 'origin ${{ github.event.push.ref }}'
+
+    - name: Create pull request
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      shell: bash -l {0}
+      run: |
+        gh pr create --title "Release ${{ env.RELEASE_VERSION }}" --body ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# [v3.1.4](https://github.com/bagherilab/ARCADE/releases/tag/v3.1.4) - 2024-02-26
+
+> Compare with [v3.1.3](https://github.com/bagherilab/ARCADE/compare/v3.1.3...v3.1.4)
+
+# [v3.1.3](https://github.com/bagherilab/ARCADE/releases/tag/v3.1.3) - 2024-02-05
+
+> Compare with [v3.1.2](https://github.com/bagherilab/ARCADE/compare/v3.1.2...v3.1.3)
+
+### Features
+
+- Add version to output files by [@jessicasyu](https://github.com/jessicasyu) in [#7](https://github.com/bagherilab/ARCADE/pull/7)
+
+### Bug fixes
+
+- Swap voxel update order by [@jessicasyu](https://github.com/jessicasyu) in [#8](https://github.com/bagherilab/ARCADE/pull/8)
+
+# [v3.1.2](https://github.com/bagherilab/ARCADE/releases/tag/v3.1.2) - 2023-11-14
+
+> Compare with [v3.1.1](https://github.com/bagherilab/ARCADE/compare/v3.1.1...v3.1.2)
+
+### Features
+
+- Convert core enums to use interfaces by [@jessicasyu](https://github.com/jessicasyu) in [#3](https://github.com/bagherilab/ARCADE/pull/3)
+- Update minibox to load simple fractions by [@jessicasyu](https://github.com/jessicasyu) in [#5](https://github.com/bagherilab/ARCADE/pull/5)
+
+### Bug fixes
+
+- Update size checkpoints in potts modules by [@jessicasyu](https://github.com/jessicasyu) in [#2](https://github.com/bagherilab/ARCADE/pull/2)
+
+### Tests
+
+- Update region adhesion unit tests by [@jessicasyu](https://github.com/jessicasyu) in [#6](https://github.com/bagherilab/ARCADE/pull/6)
+
+### Admin
+
+- Update version handling in gradle build by [@jessicasyu](https://github.com/jessicasyu) in [#4](https://github.com/bagherilab/ARCADE/pull/4)
+
+# [v3.1.1](https://github.com/bagherilab/ARCADE/releases/tag/v3.1.1) - 2023-10-03
+
+> Compare with [v3.1.0](https://github.com/bagherilab/ARCADE/compare/v3.1.0...v3.1.1)
+
+# [v3.1.0](https://github.com/bagherilab/ARCADE/releases/tag/v3.1.0) - 2023-03-01
+
+> Compare with [v3.0.1](https://github.com/bagherilab/ARCADE/compare/v3.0.1...v3.1.0)
+
+# [v3.0.1](https://github.com/bagherilab/ARCADE/releases/tag/v3.0.1) - 2023-10-03
+
+> Compare with [v3.0.0](https://github.com/bagherilab/ARCADE/compare/v3.0.0...v3.0.1)
+
+# [v3.0.0](https://github.com/bagherilab/ARCADE/releases/tag/v3.0.0) - 2023-01-31
+
+> Compare with [v2.4](https://github.com/bagherilab/ARCADE/compare/v2.4...v3.0.0)


### PR DESCRIPTION
Sets up proposed release workflow:

1. We decide to publish a release
2. Create a release branch `release/v#.#.#`
3. Bump version using Gradle (`bumpMajor` or `bumpMinor` or `bumpPatch`)
4. Commit the updated `gradle.build` and `version.properties`
5. Push the release branch, which triggers the `release` workflow:
    - Updates `CHANGELOG.md` based on all PRs between previous release and this one
    - Creates a release PR `Release v#.#.#`
6. Review PR to check and make any edits
7. Merge release PR, which triggers the `publish` workflow:
    - Generates a GitHub release 
    - Updates the version badge