### PR TITLE
Add support for adding criticalAge to induce apoptosis

### DIFF
--- a/src/arcade/patch/agent/action/PatchActionConvert.java
+++ b/src/arcade/patch/agent/action/PatchActionConvert.java
@@ -87,7 +87,8 @@ public class PatchActionConvert implements Action {
                         oldCell.getVolume(),
                         oldCell.getHeight(),
                         oldCell.getCriticalVolume(),
-                        oldCell.getCriticalHeight());
+                        oldCell.getCriticalHeight(),
+                        oldCell.getCriticalAge());
         PatchCell newCell =
                 (PatchCell) cellContainer.convert(sim.cellFactory, location, sim.random);
         grid.addObject(newCell, location);

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -101,6 +101,9 @@ public abstract class PatchCell implements Cell {
     /** Critical height for cell [um]. */
     final double criticalHeight;
 
+    /** Critical age for cell [min] */
+    double criticalAge;
+
     /** Cell state change flag. */
     private Flag flag;
 
@@ -155,6 +158,7 @@ public abstract class PatchCell implements Cell {
         this.height = container.height;
         this.criticalVolume = container.criticalVolume;
         this.criticalHeight = container.criticalHeight;
+        this.criticalAge = container.criticalAge;
         this.flag = Flag.UNDEFINED;
         this.parameters = parameters;
         this.links = links;
@@ -245,6 +249,15 @@ public abstract class PatchCell implements Cell {
     @Override
     public double getCriticalHeight() {
         return criticalHeight;
+    }
+
+    /**
+     * Get the critical cell age for apoptosis
+     *
+     * @return the apoptosis age
+     */
+    public double getCriticalAge() {
+        return criticalAge;
     }
 
     /**
@@ -339,8 +352,9 @@ public abstract class PatchCell implements Cell {
 
         // Increase age of cell.
         age++;
-
-        // TODO: check for death due to age
+        if (age > criticalAge) {
+            setState(State.APOPTOTIC);
+        }
 
         // Step metabolism process.
         processes.get(Domain.METABOLISM).step(simstate.random, sim);
@@ -395,7 +409,8 @@ public abstract class PatchCell implements Cell {
                 volume,
                 height,
                 criticalVolume,
-                criticalHeight);
+                criticalHeight,
+                criticalAge);
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCellCancer.java
+++ b/src/arcade/patch/agent/cell/PatchCellCancer.java
@@ -71,7 +71,8 @@ public class PatchCellCancer extends PatchCellTissue {
                 volume,
                 height,
                 criticalVolume,
-                criticalHeight);
+                criticalHeight,
+                criticalAge);
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCellCancerStem.java
+++ b/src/arcade/patch/agent/cell/PatchCellCancerStem.java
@@ -43,7 +43,7 @@ public class PatchCellCancerStem extends PatchCellCancer {
             PatchCellContainer container, Location location, Parameters parameters, GrabBag links) {
         super(container, location, parameters, links);
 
-        // TODO: set death age
+        this.criticalAge = Double.MAX_VALUE;
     }
 
     /**
@@ -65,6 +65,7 @@ public class PatchCellCancerStem extends PatchCellCancer {
                 volume,
                 height,
                 criticalVolume,
-                criticalHeight);
+                criticalHeight,
+                criticalAge);
     }
 }

--- a/src/arcade/patch/agent/cell/PatchCellContainer.java
+++ b/src/arcade/patch/agent/cell/PatchCellContainer.java
@@ -47,6 +47,9 @@ public final class PatchCellContainer implements CellContainer {
     /** Critical cell height [um]. */
     public final double criticalHeight;
 
+    /** Critical cell age [min] */
+    public final double criticalAge;
+
     /**
      * Creates a {@code PatchCellContainer} instance.
      *
@@ -71,7 +74,8 @@ public final class PatchCellContainer implements CellContainer {
             double volume,
             double height,
             double criticalVolume,
-            double criticalHeight) {
+            double criticalHeight,
+            double criticalAge) {
         this.id = id;
         this.parent = parent;
         this.pop = pop;
@@ -82,6 +86,7 @@ public final class PatchCellContainer implements CellContainer {
         this.height = height;
         this.criticalVolume = criticalVolume;
         this.criticalHeight = criticalHeight;
+        this.criticalAge = criticalAge;
     }
 
     @Override

--- a/src/arcade/patch/agent/cell/PatchCellFactory.java
+++ b/src/arcade/patch/agent/cell/PatchCellFactory.java
@@ -159,6 +159,7 @@ public final class PatchCellFactory implements CellFactory {
         double volume = parameters.getDouble("CELL_VOLUME");
         double height = parameters.getDouble("CELL_HEIGHT");
         int age = parameters.getInt("CELL_AGE");
+        double apototicAge = parameters.getDouble("APOPTOSIS_AGE");
 
         return new PatchCellContainer(
                 id,
@@ -170,7 +171,8 @@ public final class PatchCellFactory implements CellFactory {
                 volume,
                 height,
                 volume,
-                height + compression);
+                height + compression,
+                apototicAge);
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCellRandom.java
+++ b/src/arcade/patch/agent/cell/PatchCellRandom.java
@@ -56,7 +56,8 @@ public class PatchCellRandom extends PatchCell {
                 volume,
                 height,
                 criticalVolume,
-                criticalHeight);
+                criticalHeight,
+                criticalAge);
     }
 
     @Override

--- a/src/arcade/patch/agent/cell/PatchCellTissue.java
+++ b/src/arcade/patch/agent/cell/PatchCellTissue.java
@@ -46,6 +46,7 @@ public class PatchCellTissue extends PatchCell {
                 volume,
                 height,
                 criticalVolume,
-                criticalHeight);
+                criticalHeight,
+                criticalAge);
     }
 }

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -13,6 +13,7 @@
     <population id="CELL_VOLUME" value="NORMAL(MU=2250,SIGMA=200)" unit="um^3" description="cell volume distribution" />
     <population id="CELL_HEIGHT" value="NORMAL(MU=8.7,SIGMA=0)" unit="um" description="cell height distribution" />
     <population id="CELL_AGE" value="UNIFORM(MIN=0,MAX=120960)" unit="min" description="cell age distribution" />
+    <population id="APOPTOSIS_AGE" value="NORMAL(MU=120960,SIGMA=10080)" unit="min" description="cell apoptosis age distribution" />
     <population id="DIVISION_POTENTIAL" value="50" description="maximum number of divisions" />
     <population id="COMPRESSION_TOLERANCE" value="0" units="um" description="maximum compression tolerance" />
     <population id="HETEROGENEITY" value="0.0" description="variation in cell agent parameters" />

--- a/src/arcade/patch/sim/output/PatchOutputDeserializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputDeserializer.java
@@ -73,6 +73,7 @@ public final class PatchOutputDeserializer {
             JsonArray criticals = jsonObject.get("criticals").getAsJsonArray();
             double criticalVolume = criticals.get(0).getAsDouble();
             double criticalHeight = criticals.get(1).getAsDouble();
+            double criticalAge = criticals.get(2).getAsDouble();
 
             return new PatchCellContainer(
                     id,
@@ -84,7 +85,8 @@ public final class PatchOutputDeserializer {
                     volume,
                     height,
                     criticalVolume,
-                    criticalHeight);
+                    criticalHeight,
+                    criticalAge);
         }
     }
 

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -143,6 +143,7 @@ public final class PatchOutputSerializer {
             JsonArray criticals = new JsonArray();
             criticals.add((int) (100 * src.criticalVolume) / 100.0);
             criticals.add((int) (100 * src.criticalHeight) / 100.0);
+            criticals.add((int) (100 * src.criticalAge) / 100.0);
             json.add("criticals", criticals);
 
             // TODO: add cycles

--- a/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
@@ -1,0 +1,98 @@
+package arcade.patch.agent.cell;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import arcade.core.util.MiniBox;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.module.PatchModule;
+import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSignaling;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.*;
+import static arcade.patch.util.PatchEnums.Domain;
+import static arcade.patch.util.PatchEnums.State;
+
+
+public class PatchCellCancerStemTest {
+    static PatchSimulation simMock;
+
+    static PatchLocation locationMock;
+
+    static Parameters parametersMock;
+
+    static PatchProcessMetabolism metabolismMock;
+
+    static PatchProcessSignaling signalingMock;
+
+    static int cellID = randomIntBetween(1, 10);
+
+    static int cellParent = randomIntBetween(1, 10);
+
+    static int cellPop = randomIntBetween(1, 10);
+
+    static int cellAge = randomIntBetween(1, 1000);
+
+    static int cellDivisions = randomIntBetween(1, 100);
+
+    static double cellVolume = randomDoubleBetween(10, 100);
+
+    static double cellHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalVolume = randomDoubleBetween(10, 100);
+
+    static double cellCriticalHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalAge = randomDoubleBetween(900, 1100);
+
+    static State cellState = State.QUIESCENT;
+
+    @BeforeAll
+    public static void setupMocks() {
+        simMock = mock(PatchSimulation.class);
+        locationMock = mock(PatchLocation.class);
+        parametersMock = spy(new Parameters(new MiniBox(), null, null));
+        metabolismMock = mock(PatchProcessMetabolism.class);
+        signalingMock = mock(PatchProcessSignaling.class);
+    }
+
+    @Test
+    public void step_calledWhenAgeGreaterThanCriticalAge_doesNotSetApoptoticState() {
+        PatchModule module = mock(PatchModule.class);
+
+        PatchCellContainer container =
+                new PatchCellContainer(
+                        cellID,
+                        cellParent,
+                        cellPop,
+                        cellAge,
+                        cellDivisions,
+                        cellState,
+                        cellVolume,
+                        cellHeight,
+                        cellCriticalVolume,
+                        cellCriticalHeight,
+                        cellAge - 1);
+
+        doReturn(0.).when(parametersMock).getDouble(anyString());
+        doReturn(0).when(parametersMock).getInt(anyString());
+        PatchCell cell = spy(new PatchCellCancerStem(container, locationMock, parametersMock));
+        cell.processes.put(Domain.METABOLISM, metabolismMock);
+        cell.processes.put(Domain.SIGNALING, signalingMock);
+        doAnswer(
+                        invocationOnMock -> {
+                            cell.state = invocationOnMock.getArgument(0);
+                            cell.module = module;
+                            return null;
+                        })
+                .when(cell)
+                .setState(any(State.class));
+
+        cell.step(simMock);
+
+        assertEquals(State.QUIESCENT, cell.getState());
+    }
+}

--- a/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellFactoryTest.java
@@ -49,6 +49,7 @@ public class PatchCellFactoryTest {
         int age = randomIntBetween(1, 100);
         int divisions = randomIntBetween(1, 100);
         double compression = randomDoubleBetween(1, 10);
+        double critAge = randomDoubleBetween(50, 150);
 
         MiniBox parameters = new MiniBox();
         parameters.put("CELL_VOLUME", volume);
@@ -56,6 +57,7 @@ public class PatchCellFactoryTest {
         parameters.put("CELL_AGE", age);
         parameters.put("DIVISION_POTENTIAL", divisions);
         parameters.put("COMPRESSION_TOLERANCE", compression);
+        parameters.put("APOPTOSIS_AGE", critAge);
 
         PatchCellFactory factory = new PatchCellFactory();
         factory.popToIDs.put(1, new HashSet<>());
@@ -71,6 +73,7 @@ public class PatchCellFactoryTest {
             assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
             assertEquals(age, patchCellContainer.age);
             assertEquals(divisions, patchCellContainer.divisions);
+            assertEquals(critAge, patchCellContainer.criticalAge);
         }
     }
 
@@ -89,6 +92,7 @@ public class PatchCellFactoryTest {
         int age = randomIntBetween(1, 100);
         int divisions = randomIntBetween(1, 100);
         double compression = randomDoubleBetween(1, 10);
+        double critAge = randomDoubleBetween(50, 150);
 
         MiniBox parameters = new MiniBox();
         parameters.put("CELL_VOLUME", volume);
@@ -96,6 +100,7 @@ public class PatchCellFactoryTest {
         parameters.put("CELL_AGE", age);
         parameters.put("DIVISION_POTENTIAL", divisions);
         parameters.put("COMPRESSION_TOLERANCE", compression);
+        parameters.put("APOPTOSIS_AGE", critAge);
 
         PatchCellFactory factory = new PatchCellFactory();
         factory.popToIDs.put(1, new HashSet<>());
@@ -111,6 +116,7 @@ public class PatchCellFactoryTest {
             assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
             assertEquals(age, patchCellContainer.age);
             assertEquals(divisions, patchCellContainer.divisions);
+            assertEquals(critAge, patchCellContainer.criticalAge);
         }
     }
 
@@ -128,6 +134,7 @@ public class PatchCellFactoryTest {
         int age = randomIntBetween(1, 100);
         int divisions = randomIntBetween(1, 100);
         double compression = randomDoubleBetween(1, 10);
+        double critAge = randomDoubleBetween(50, 150);
 
         MiniBox parameters = new MiniBox();
         parameters.put("CELL_VOLUME", volume);
@@ -135,6 +142,7 @@ public class PatchCellFactoryTest {
         parameters.put("CELL_AGE", age);
         parameters.put("DIVISION_POTENTIAL", divisions);
         parameters.put("COMPRESSION_TOLERANCE", compression);
+        parameters.put("APOPTOSIS_AGE", critAge);
 
         PatchCellFactory factory = new PatchCellFactory();
         factory.popToIDs.put(1, new HashSet<>());
@@ -150,6 +158,7 @@ public class PatchCellFactoryTest {
             assertEquals(height + compression, patchCellContainer.criticalHeight, EPSILON);
             assertEquals(age, patchCellContainer.age);
             assertEquals(divisions, patchCellContainer.divisions);
+            assertEquals(critAge, patchCellContainer.criticalAge);
         }
     }
 
@@ -194,6 +203,12 @@ public class PatchCellFactoryTest {
                     randomDoubleBetween(1, 10),
                     randomDoubleBetween(1, 10),
                 };
+        double[] apotosisAges =
+                new double[] {
+                    randomDoubleBetween(50, 150),
+                    randomDoubleBetween(50, 150),
+                    randomDoubleBetween(50, 150),
+                };
 
         MiniBox parameters1 = new MiniBox();
         parameters1.put("CELL_VOLUME", volumes[0]);
@@ -201,6 +216,7 @@ public class PatchCellFactoryTest {
         parameters1.put("CELL_AGE", ages[0]);
         parameters1.put("DIVISION_POTENTIAL", divisions[0]);
         parameters1.put("COMPRESSION_TOLERANCE", compressions[0]);
+        parameters1.put("APOPTOSIS_AGE", apotosisAges[0]);
 
         MiniBox parameters2 = new MiniBox();
         parameters2.put("CELL_VOLUME", volumes[1]);
@@ -208,6 +224,7 @@ public class PatchCellFactoryTest {
         parameters2.put("CELL_AGE", ages[1]);
         parameters2.put("DIVISION_POTENTIAL", divisions[1]);
         parameters2.put("COMPRESSION_TOLERANCE", compressions[1]);
+        parameters2.put("APOPTOSIS_AGE", apotosisAges[1]);
 
         MiniBox parameters3 = new MiniBox();
         parameters3.put("CELL_VOLUME", volumes[2]);
@@ -215,6 +232,7 @@ public class PatchCellFactoryTest {
         parameters3.put("CELL_AGE", ages[2]);
         parameters3.put("DIVISION_POTENTIAL", divisions[2]);
         parameters3.put("COMPRESSION_TOLERANCE", compressions[2]);
+        parameters3.put("APOPTOSIS_AGE", apotosisAges[2]);
 
         PatchCellFactory factory = new PatchCellFactory();
         factory.popToIDs.put(1, new HashSet<>());
@@ -237,6 +255,7 @@ public class PatchCellFactoryTest {
             assertEquals(heights[0] + compressions[0], patchCellContainer.criticalHeight, EPSILON);
             assertEquals(ages[0], patchCellContainer.age);
             assertEquals(divisions[0], patchCellContainer.divisions);
+            assertEquals(apotosisAges[0], patchCellContainer.criticalAge);
         }
         for (int i : factory.popToIDs.get(2)) {
             PatchCellContainer patchCellContainer = factory.cells.get(i);
@@ -244,6 +263,7 @@ public class PatchCellFactoryTest {
             assertEquals(heights[1] + compressions[1], patchCellContainer.criticalHeight, EPSILON);
             assertEquals(ages[1], patchCellContainer.age);
             assertEquals(divisions[1], patchCellContainer.divisions);
+            assertEquals(apotosisAges[1], patchCellContainer.criticalAge);
         }
         for (int i : factory.popToIDs.get(3)) {
             PatchCellContainer patchCellContainer = factory.cells.get(i);
@@ -251,6 +271,7 @@ public class PatchCellFactoryTest {
             assertEquals(heights[2] + compressions[2], patchCellContainer.criticalHeight, EPSILON);
             assertEquals(ages[2], patchCellContainer.age);
             assertEquals(divisions[2], patchCellContainer.divisions);
+            assertEquals(apotosisAges[2], patchCellContainer.criticalAge);
         }
     }
 }

--- a/test/arcade/patch/agent/cell/PatchCellRandomTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellRandomTest.java
@@ -11,6 +11,7 @@ import arcade.patch.agent.process.PatchProcessMetabolism;
 import arcade.patch.env.location.PatchLocation;
 import arcade.patch.sim.PatchSimulation;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
 import static arcade.patch.util.PatchEnums.Domain;
@@ -41,6 +42,8 @@ public class PatchCellRandomTest {
 
     static double cellCriticalHeight = randomDoubleBetween(10, 100);
 
+    static double cellCriticalAge = randomDoubleBetween(900, 1100);
+
     static State cellState = State.QUIESCENT;
 
     static PatchCellContainer baseContainer =
@@ -54,7 +57,8 @@ public class PatchCellRandomTest {
                     cellVolume,
                     cellHeight,
                     cellCriticalVolume,
-                    cellCriticalHeight);
+                    cellCriticalHeight,
+                    cellCriticalAge);
 
     @BeforeAll
     public static void setupMocks() {
@@ -70,6 +74,7 @@ public class PatchCellRandomTest {
         double height = randomDoubleBetween(10, 100);
         double criticalVolume = randomDoubleBetween(10, 100);
         double criticalHeight = randomDoubleBetween(10, 100);
+        double criticalAge = randomDoubleBetween(1, 1000);
         State state1 = State.QUIESCENT;
         State state2 = State.PROLIFERATIVE;
 
@@ -84,7 +89,8 @@ public class PatchCellRandomTest {
                         volume,
                         height,
                         criticalVolume,
-                        criticalHeight);
+                        criticalHeight,
+                        criticalAge);
         PatchCellRandom cell =
                 new PatchCellRandom(cellContainer, locationMock, parametersMock, null);
 
@@ -109,6 +115,7 @@ public class PatchCellRandomTest {
         double height = randomDoubleBetween(10, 100);
         double criticalVolume = randomDoubleBetween(10, 100);
         double criticalHeight = randomDoubleBetween(10, 100);
+        double criticalAge = randomDoubleBetween(1, 1000);
         State state1 = State.QUIESCENT;
         State state2 = State.PROLIFERATIVE;
 
@@ -130,7 +137,8 @@ public class PatchCellRandomTest {
                         volume,
                         height,
                         criticalVolume,
-                        criticalHeight);
+                        criticalHeight,
+                        criticalAge);
 
         PatchCellRandom cell =
                 new PatchCellRandom(cellContainer, locationMock, parametersMock, links);

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -1,0 +1,123 @@
+package arcade.patch.agent.cell;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.cell.CellState;
+import arcade.core.env.location.*;
+import arcade.core.util.MiniBox;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.module.PatchModule;
+import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSignaling;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.Domain;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.*;
+import static arcade.patch.util.PatchEnums.State;
+
+public class PatchCellTest {
+    static PatchSimulation simMock;
+
+    static PatchLocation locationMock;
+
+    static Parameters parametersMock;
+
+    static PatchProcessMetabolism metabolismMock;
+
+    static PatchProcessSignaling signalingMock;
+
+    static int cellID = randomIntBetween(1, 10);
+
+    static int cellParent = randomIntBetween(1, 10);
+
+    static int cellPop = randomIntBetween(1, 10);
+
+    static int cellAge = randomIntBetween(1, 1000);
+
+    static int cellDivisions = randomIntBetween(1, 100);
+
+    static double cellVolume = randomDoubleBetween(10, 100);
+
+    static double cellHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalVolume = randomDoubleBetween(10, 100);
+
+    static double cellCriticalHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalAge = randomDoubleBetween(900, 1100);
+
+    static State cellState = State.QUIESCENT;
+
+    static class PatchCellMock extends PatchCell {
+        PatchCellMock(PatchCellContainer container, Location location, Parameters parameters) {
+            super(container, location, parameters, null);
+        }
+
+        @Override
+        public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
+            return new PatchCellContainer(
+                    cellID,
+                    cellParent,
+                    cellPop,
+                    cellAge,
+                    cellDivisions,
+                    cellState,
+                    cellVolume,
+                    cellHeight,
+                    cellCriticalVolume,
+                    cellCriticalHeight,
+                    cellCriticalAge);
+        }
+    }
+
+    @BeforeAll
+    public static void setupMocks() {
+        simMock = mock(PatchSimulation.class);
+        locationMock = mock(PatchLocation.class);
+        parametersMock = spy(new Parameters(new MiniBox(), null, null));
+        metabolismMock = mock(PatchProcessMetabolism.class);
+        signalingMock = mock(PatchProcessSignaling.class);
+    }
+
+    @Test
+    public void step_calledWhenAgeGreaterThanApoptoticAge_setsApoptoticState() {
+        PatchModule module = mock(PatchModule.class);
+
+        PatchCellContainer container =
+                new PatchCellContainer(
+                        cellID,
+                        cellParent,
+                        cellPop,
+                        cellAge,
+                        cellDivisions,
+                        cellState,
+                        cellVolume,
+                        cellHeight,
+                        cellCriticalVolume,
+                        cellCriticalHeight,
+                        cellAge - 1);
+
+        doReturn(0.).when(parametersMock).getDouble(anyString());
+        doReturn(0).when(parametersMock).getInt(anyString());
+        PatchCell cell = spy(new PatchCellMock(container, locationMock, parametersMock));
+        cell.processes.put(Domain.METABOLISM, metabolismMock);
+        cell.processes.put(Domain.SIGNALING, signalingMock);
+        doAnswer(
+                        invocationOnMock -> {
+                            cell.state = invocationOnMock.getArgument(0);
+                            cell.module = module;
+                            return null;
+                        })
+                .when(cell)
+                .setState(any(State.class));
+
+        cell.step(simMock);
+
+        assertEquals(State.APOPTOTIC, cell.getState());
+    }
+}


### PR DESCRIPTION
Resolves #31.

_Estimated size: medium_

Adds the following option to the `parameters.patch.xml`
```xml
 <population id="APOPTOSIS_AGE" value="NORMAL(MU=120960,SIGMA=10080)" unit="min" description="cell apoptosis age distribution" />
```

Summary of major changes: 
- Adds a `criticalAge` to cell containers, and includes adding as part of the criticals in the output. 
- PatchCells enter an apoptotic state if the age is greater than the critical age. 
- Stem cells set the critical age to a Double.MAX_VALUE. 

