### PR TITLE
Add apoptosis age to induce change to apoptotic state

### DIFF
--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -364,7 +364,7 @@ public abstract class PatchCell implements Cell {
         // Increase age of cell.
         age++;
 
-        if (age > apoptosisAge) {
+        if (state != State.APOPTOTIC && age > apoptosisAge) {
             setState(State.APOPTOTIC);
         }
 

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -95,6 +95,9 @@ public abstract class PatchCell implements Cell {
     /** Cell height [um]. */
     double height;
 
+    /** Death age due to apoptosis [min]. */
+    double apoptosisAge;
+
     /** Critical volume for cell [um<sup>3</sup>]. */
     final double criticalVolume;
 
@@ -168,6 +171,7 @@ public abstract class PatchCell implements Cell {
         necroticFraction = parameters.getDouble("NECROTIC_FRACTION");
         senescentFraction = parameters.getDouble("SENESCENT_FRACTION");
         energyThreshold = -parameters.getDouble("ENERGY_THRESHOLD");
+        apoptosisAge = parameters.getDouble("APOPTOSIS_AGE");
 
         // Add cell processes.
         processes = new HashMap<>();
@@ -360,7 +364,9 @@ public abstract class PatchCell implements Cell {
         // Increase age of cell.
         age++;
 
-        // TODO: check for death due to age
+        if (age > apoptosisAge) {
+            setState(State.APOPTOTIC);
+        }
 
         // Step metabolism process.
         processes.get(Domain.METABOLISM).step(simstate.random, sim);

--- a/src/arcade/patch/agent/cell/PatchCellCancerStem.java
+++ b/src/arcade/patch/agent/cell/PatchCellCancerStem.java
@@ -43,7 +43,7 @@ public class PatchCellCancerStem extends PatchCellCancer {
             PatchCellContainer container, Location location, Parameters parameters, GrabBag links) {
         super(container, location, parameters, links);
 
-        // TODO: set death age
+        this.apoptosisAge = Double.MAX_VALUE;
     }
 
     /**

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -13,6 +13,7 @@
     <population id="CELL_VOLUME" value="NORMAL(MU=2250,SIGMA=200)" unit="um^3" description="cell volume distribution" />
     <population id="CELL_HEIGHT" value="NORMAL(MU=8.7,SIGMA=0)" unit="um" description="cell height distribution" />
     <population id="CELL_AGE" value="UNIFORM(MIN=0,MAX=120960)" unit="min" description="cell age distribution" />
+    <population id="APOPTOSIS_AGE" value="NORMAL(MU=120960,SIGMA=10080)" unit="min" description="cell apoptosis age distribution" />
     <population id="DIVISION_POTENTIAL" value="50" description="maximum number of divisions" />
     <population id="COMPRESSION_TOLERANCE" value="0" units="um" description="maximum compression tolerance" />
     <population id="HETEROGENEITY" value="0.0" description="variation in cell agent parameters" />

--- a/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
@@ -1,0 +1,106 @@
+package arcade.patch.agent.cell;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import arcade.core.util.MiniBox;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.module.PatchModule;
+import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSignaling;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.*;
+import static arcade.patch.util.PatchEnums.Domain;
+import static arcade.patch.util.PatchEnums.State;
+
+public class PatchCellCancerStemTest {
+    static PatchSimulation simMock;
+
+    static PatchLocation locationMock;
+
+    static Parameters parametersMock;
+
+    static PatchProcessMetabolism metabolismMock;
+
+    static PatchProcessSignaling signalingMock;
+
+    static int cellID = randomIntBetween(1, 10);
+
+    static int cellParent = randomIntBetween(1, 10);
+
+    static int cellPop = randomIntBetween(1, 10);
+
+    static int cellAge = randomIntBetween(1, 1000);
+
+    static int cellDivisions = randomIntBetween(1, 100);
+
+    static double cellVolume = randomDoubleBetween(10, 100);
+
+    static double cellHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalVolume = randomDoubleBetween(10, 100);
+
+    static double cellCriticalHeight = randomDoubleBetween(10, 100);
+
+    static double cellCriticalAge = randomDoubleBetween(900, 1100);
+
+    static State cellState = State.QUIESCENT;
+
+    @BeforeAll
+    public static void setupMocks() {
+        simMock = mock(PatchSimulation.class);
+        locationMock = mock(PatchLocation.class);
+        parametersMock = spy(new Parameters(new MiniBox(), null, null));
+        metabolismMock = mock(PatchProcessMetabolism.class);
+        signalingMock = mock(PatchProcessSignaling.class);
+    }
+
+    @Test
+    public void step_calledWhenAgeGreaterThanApoptosisAge_doesNotSetApoptoticState() {
+        PatchModule module = mock(PatchModule.class);
+        doReturn(0.).when(parametersMock).getDouble(anyString());
+        doReturn(0).when(parametersMock).getInt(anyString());
+        doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
+
+        ArrayList<State> relevantStates = new ArrayList<>();
+        relevantStates.add(State.QUIESCENT);
+        relevantStates.add(State.MIGRATORY);
+        relevantStates.add(State.PROLIFERATIVE);
+
+        for (State state : relevantStates) {
+            PatchCellContainer container =
+                    new PatchCellContainer(
+                            cellID,
+                            cellParent,
+                            cellPop,
+                            11,
+                            cellDivisions,
+                            state,
+                            cellVolume,
+                            cellHeight,
+                            cellCriticalVolume,
+                            cellCriticalHeight);
+            PatchCell cell = spy(new PatchCellCancerStem(container, locationMock, parametersMock));
+            cell.module = module;
+            cell.processes.put(Domain.METABOLISM, metabolismMock);
+            cell.processes.put(Domain.SIGNALING, signalingMock);
+            doAnswer(
+                            invocationOnMock -> {
+                                cell.state = invocationOnMock.getArgument(0);
+                                cell.module = module;
+                                return null;
+                            })
+                    .when(cell)
+                    .setState(any(State.class));
+
+            cell.step(simMock);
+
+            assertEquals(state, cell.getState());
+        }
+    }
+}

--- a/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellCancerStemTest.java
@@ -66,7 +66,7 @@ public class PatchCellCancerStemTest {
         doReturn(0.).when(parametersMock).getDouble(anyString());
         doReturn(0).when(parametersMock).getInt(anyString());
         doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
-
+        int age = 11;
         ArrayList<State> relevantStates = new ArrayList<>();
         relevantStates.add(State.QUIESCENT);
         relevantStates.add(State.MIGRATORY);
@@ -78,7 +78,7 @@ public class PatchCellCancerStemTest {
                             cellID,
                             cellParent,
                             cellPop,
-                            11,
+                            age,
                             cellDivisions,
                             state,
                             cellVolume,

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -240,7 +240,5 @@ public class PatchCellTest {
         cell.step(simMock);
 
         verify(cell, times(0)).setState(any(State.class));
-
     }
-
 }

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -124,7 +124,7 @@ public class PatchCellTest {
         doReturn(0.0).when(parametersMock).getDouble(any(String.class));
         doReturn(0).when(parametersMock).getInt(any(String.class));
         doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
-
+        int age = 11;
         ArrayList<State> relevantStates = new ArrayList<>();
         relevantStates.add(State.QUIESCENT);
         relevantStates.add(State.MIGRATORY);
@@ -136,7 +136,7 @@ public class PatchCellTest {
                             cellID,
                             cellParent,
                             cellPop,
-                            11,
+                            age,
                             cellDivisions,
                             state,
                             cellVolume,
@@ -162,12 +162,12 @@ public class PatchCellTest {
     }
 
     @Test
-    public void step_calledWhenAgeLessThanApoptosisAge_doesNotSet() {
+    public void step_calledWhenAgeLessThanApoptosisAge_doesNotSetState() {
         PatchModule module = mock(PatchModule.class);
         doReturn(0.0).when(parametersMock).getDouble(any(String.class));
         doReturn(0).when(parametersMock).getInt(any(String.class));
         doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
-
+        int age = 9;
         ArrayList<State> relevantStates = new ArrayList<>();
         relevantStates.add(State.QUIESCENT);
         relevantStates.add(State.MIGRATORY);
@@ -179,7 +179,7 @@ public class PatchCellTest {
                             cellID,
                             cellParent,
                             cellPop,
-                            9,
+                            age,
                             cellDivisions,
                             state,
                             cellVolume,
@@ -203,4 +203,44 @@ public class PatchCellTest {
             assertEquals(state, cell.getState());
         }
     }
+
+    @Test
+    public void step_calledApoptoticStateAndApoptoticAge_doesNotResetState() {
+        PatchModule module = mock(PatchModule.class);
+        doReturn(0.0).when(parametersMock).getDouble(any(String.class));
+        doReturn(0).when(parametersMock).getInt(any(String.class));
+        doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
+        int age = 12;
+        State state = State.APOPTOTIC;
+
+        PatchCellContainer container =
+                new PatchCellContainer(
+                        cellID,
+                        cellParent,
+                        cellPop,
+                        age,
+                        cellDivisions,
+                        state,
+                        cellVolume,
+                        cellHeight,
+                        cellCriticalVolume,
+                        cellCriticalHeight);
+        PatchCell cell = spy(new PatchCellMock(container, locationMock, parametersMock));
+        cell.processes.put(Domain.METABOLISM, metabolismMock);
+        cell.processes.put(Domain.SIGNALING, signalingMock);
+        cell.module = module;
+        doAnswer(
+                        invocationOnMock -> {
+                            cell.state = invocationOnMock.getArgument(0);
+                            return null;
+                        })
+                .when(cell)
+                .setState(any(State.class));
+
+        cell.step(simMock);
+
+        verify(cell, times(0)).setState(any(State.class));
+
+    }
+
 }

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -1,5 +1,6 @@
 package arcade.patch.agent.cell;
 
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import ec.util.MersenneTwisterFast;
@@ -7,20 +8,28 @@ import arcade.core.agent.cell.CellState;
 import arcade.core.env.location.*;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Parameters;
+import arcade.patch.agent.module.PatchModule;
+import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSignaling;
 import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.Domain;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
 import static arcade.patch.util.PatchEnums.State;
 
 public class PatchCellTest {
-    private static final double EPSILON = 1E-8;
-
-    private static final MersenneTwisterFast RANDOM = new MersenneTwisterFast();
+    static PatchSimulation simMock;
 
     static PatchLocation locationMock;
 
     static Parameters parametersMock;
+
+    static PatchProcessMetabolism metabolismMock;
+
+    static PatchProcessSignaling signalingMock;
 
     static int cellID = randomIntBetween(1, 10);
 
@@ -78,8 +87,11 @@ public class PatchCellTest {
 
     @BeforeAll
     public static void setupMocks() {
+        simMock = mock(PatchSimulation.class);
         locationMock = mock(PatchLocation.class);
         parametersMock = spy(new Parameters(new MiniBox(), null, null));
+        metabolismMock = mock(PatchProcessMetabolism.class);
+        signalingMock = mock(PatchProcessSignaling.class);
     }
 
     @Test
@@ -104,5 +116,91 @@ public class PatchCellTest {
         assertEquals(3, cell.getCycles().get(1));
         assertEquals(5, cell.getCycles().get(2));
         assertEquals(3, cell.getCycles().size());
+    }
+
+    @Test
+    public void step_calledWhenAgeGreaterThanApoptosisAge_setsApoptoticState() {
+        PatchModule module = mock(PatchModule.class);
+        doReturn(0.0).when(parametersMock).getDouble(any(String.class));
+        doReturn(0).when(parametersMock).getInt(any(String.class));
+        doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
+
+        ArrayList<State> relevantStates = new ArrayList<>();
+        relevantStates.add(State.QUIESCENT);
+        relevantStates.add(State.MIGRATORY);
+        relevantStates.add(State.PROLIFERATIVE);
+
+        for (State state : relevantStates) {
+            PatchCellContainer container =
+                    new PatchCellContainer(
+                            cellID,
+                            cellParent,
+                            cellPop,
+                            11,
+                            cellDivisions,
+                            state,
+                            cellVolume,
+                            cellHeight,
+                            cellCriticalVolume,
+                            cellCriticalHeight);
+            PatchCell cell = spy(new PatchCellMock(container, locationMock, parametersMock));
+            cell.processes.put(Domain.METABOLISM, metabolismMock);
+            cell.processes.put(Domain.SIGNALING, signalingMock);
+            cell.module = module;
+            doAnswer(
+                            invocationOnMock -> {
+                                cell.state = invocationOnMock.getArgument(0);
+                                return null;
+                            })
+                    .when(cell)
+                    .setState(any(State.class));
+
+            cell.step(simMock);
+
+            assertEquals(State.APOPTOTIC, cell.getState());
+        }
+    }
+
+    @Test
+    public void step_calledWhenAgeLessThanApoptosisAge_doesNotSet() {
+        PatchModule module = mock(PatchModule.class);
+        doReturn(0.0).when(parametersMock).getDouble(any(String.class));
+        doReturn(0).when(parametersMock).getInt(any(String.class));
+        doReturn(10.0).when(parametersMock).getDouble("APOPTOSIS_AGE");
+
+        ArrayList<State> relevantStates = new ArrayList<>();
+        relevantStates.add(State.QUIESCENT);
+        relevantStates.add(State.MIGRATORY);
+        relevantStates.add(State.PROLIFERATIVE);
+
+        for (State state : relevantStates) {
+            PatchCellContainer container =
+                    new PatchCellContainer(
+                            cellID,
+                            cellParent,
+                            cellPop,
+                            9,
+                            cellDivisions,
+                            state,
+                            cellVolume,
+                            cellHeight,
+                            cellCriticalVolume,
+                            cellCriticalHeight);
+            PatchCell cell = spy(new PatchCellMock(container, locationMock, parametersMock));
+            cell.processes.put(Domain.METABOLISM, metabolismMock);
+            cell.processes.put(Domain.SIGNALING, signalingMock);
+            cell.module = module;
+            doAnswer(
+                            invocationOnMock -> {
+                                cell.state = invocationOnMock.getArgument(0);
+                                return null;
+                            })
+                    .when(cell)
+                    .setState(any(State.class));
+
+            cell.step(simMock);
+
+            assertEquals(state, cell.getState());
+        }
     }
 }


### PR DESCRIPTION
Resolves #31.

_Estimated size: small_

Adds the following option to the `parameters.patch.xml`
```xml
 <population id="APOPTOSIS_AGE" value="NORMAL(MU=120960,SIGMA=10080)" unit="min" description="cell apoptosis age distribution" />
```

Summary of major changes: 
- Patch cells enter an apoptotic state if the age is greater than the apoptosis age. 
- Stem cells set the apoptosis age to a Double.MAX_VALUE. 
