### PR TITLE
Add getString method to Parameters class

### DIFF
--- a/src/arcade/core/util/Parameters.java
+++ b/src/arcade/core/util/Parameters.java
@@ -89,6 +89,20 @@ public class Parameters {
     }
 
     /**
+     * Gets the parameter value as a string.
+     *
+     * @param key the parameter key
+     * @return the parameter value as a string
+     */
+    public String getString(String key) {
+        if (popParameters.contains(key)) {
+            return popParameters.get(key);
+        } else {
+            throw new InvalidParameterException();
+        }
+    }
+
+    /**
      * Gets the parameter value as a distribution, if it exists.
      *
      * @param key the parameter key

--- a/test/arcade/core/util/ParametersTest.java
+++ b/test/arcade/core/util/ParametersTest.java
@@ -174,6 +174,28 @@ public class ParametersTest {
     }
 
     @Test
+    public void getString_keyExists_returnsValue() {
+        MiniBox box = new MiniBox();
+        String key = randomString();
+        String value = randomString();
+        box.put(key, value);
+
+        Parameters parameters = new Parameters(box, null, RANDOM);
+
+        assertEquals(value, parameters.getString(key));
+    }
+
+    @Test
+    public void getString_keyDoesNotExist_throwsException() {
+        MiniBox box = new MiniBox();
+        String key = randomString();
+
+        Parameters parameters = new Parameters(box, null, RANDOM);
+
+        assertThrows(InvalidParameterException.class, () -> parameters.getString(key));
+    }
+
+    @Test
     public void getDistribution_keyHasDistribution_returnsDistribution() {
         MiniBox box = new MiniBox();
         String key = randomString();


### PR DESCRIPTION
**Estimated time to review**: small

**Linked issue**: resolves #113 

**Description of changes:**
- Added "getString" method to Parameters class that returns String-valued parameters from popParameters Minibox
- Added tests for this function

**How to verify changes:**
- Try to get a string-valued parameter that does not have a tag separator in the key in main (using filter). It will not work.
- Look at the test I wrote
- Access a string-valued parameter using the function. It will work.