### PR TITLE
Bump action versions and update docs workflow trigger

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
+  release:
+    types:
+      - published
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-gradle-javadoc:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,7 +54,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Ruby
-      uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
         bundler-cache: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -107,6 +107,8 @@ jobs:
           coverage
 
   update-documentation-badges:
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+
     runs-on: ubuntu-latest
 
     needs: deploy-github-pages
@@ -125,6 +127,14 @@ jobs:
         color: yellowgreen
         template: docs/badges/template.svg
         overwrite: true
+
+    - name: Get build result
+      run: |
+        if [[ ${{ needs.deploy-github-pages.result }} == "success" ]]; then
+          exit 0
+        else
+          exit 1
+        fi
 
     - name: Generate passing badge
       if: success()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build changelog
       id: build_changelog
-      uses: mikepenz/release-changelog-builder-action@v3.4.0
+      uses: mikepenz/release-changelog-builder-action@v5.0.0
       with:
         configurationJson: |
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Build changelog
       id: build_changelog
-      uses: mikepenz/release-changelog-builder-action@v4
+      uses: mikepenz/release-changelog-builder-action@v5.0.0
       with:
         configurationJson: |
           {


### PR DESCRIPTION
Housekeeping on some workflow action versions:

- Unpin `ruby/setup-ruby` (which should fix the current failing docs job on `main`)
- Bump `mikepenz/release-changelog-builder-action` to v5.0.0
- Fix trigger for docs badges job to always run (currently skipped if a previous job fails)
   - This should correctly generate a "failing" docs badge
   - Same strategy is used in the build and lint badge jobs
- Add trigger for docs workflow to also run when a release is published
   - This should re-trigger docs after the release workflow finished to update versions in the docs