### PR TITLE
Add flags to print CLI usage help message and version

### DIFF
--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -266,16 +266,16 @@ public abstract class ARCADE {
      */
     ArrayList<Series> buildSeries(Box parameters, MiniBox settings)
             throws IOException, SAXException {
-        String xml = settings.get("XML");
-        String path = settings.get("PATH");
+        String setupFile = settings.get("SETUP_FILE");
+        String snapshotPath = settings.get("SNAPSHOT_PATH");
         boolean isVis = settings.contains("VIS");
 
         InputBuilder builder = this.getBuilder();
-        builder.path = path.endsWith("/") ? path : (path + "/");
+        builder.path = snapshotPath.endsWith("/") ? snapshotPath : (snapshotPath + "/");
         builder.parameters = parameters;
         builder.isVis = isVis;
 
-        return builder.build(xml);
+        return builder.build(setupFile);
     }
 
     /**
@@ -289,9 +289,9 @@ public abstract class ARCADE {
      */
     void runSeries(ArrayList<Series> series, MiniBox settings) throws Exception {
         boolean isVis = settings.contains("VIS");
-        String loadPath = settings.get("LOADPATH");
-        boolean loadCells = settings.contains("LOADCELLS");
-        boolean loadLocations = settings.contains("LOADLOCATIONS");
+        String loadPath = settings.get("LOAD_PATH");
+        boolean loadCells = settings.contains("LOAD_CELLS");
+        boolean loadLocations = settings.contains("LOADL_OCATIONS");
 
         // Iterate through each series and run.
         for (Series s : series) {

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Scanner;
@@ -101,6 +102,18 @@ public abstract class ARCADE {
             throw new InvalidParameterException();
         }
 
+        // Display current model version and exit.
+        if (args[0].equals("--version")) {
+            System.out.println(loadVersion());
+            System.exit(0);
+        }
+
+        // Display help message if any help flags exist and exit.
+        if (Arrays.stream(args).anyMatch(s -> s.equals("-h") || s.equals("--help"))) {
+            System.out.println(renderHelp());
+            System.exit(0);
+        }
+
         // Extract ARCADE type.
         ARCADE arcade;
 
@@ -168,6 +181,18 @@ public abstract class ARCADE {
         } catch (Exception e) {
             return "<undefined>";
         }
+    }
+
+    /**
+     * Render help message.
+     *
+     * @return the help message
+     */
+    static String renderHelp() throws IOException, SAXException {
+        InputLoader loader = new InputLoader();
+        Box commands = loader.load(ARCADE.class.getResource("command.xml").toString());
+        InputParser parser = new InputParser(commands);
+        return parser.help("java -jar arcade-X.X.X.jar");
     }
 
     /**

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -127,7 +127,10 @@ public abstract class ARCADE {
                 arcade = new PottsARCADE();
                 break;
             default:
-                logger.warning("ARCADE [ " + args[0] + " ] does not exist");
+                logger.warning(
+                        "ARCADE implementation [ "
+                                + args[0]
+                                + " ] does not exist. Valid implementations: patch | potts");
                 throw new InvalidParameterException();
         }
 

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -291,7 +291,7 @@ public abstract class ARCADE {
         boolean isVis = settings.contains("VIS");
         String loadPath = settings.get("LOAD_PATH");
         boolean loadCells = settings.contains("LOAD_CELLS");
-        boolean loadLocations = settings.contains("LOADL_OCATIONS");
+        boolean loadLocations = settings.contains("LOAD_LOCATIONS");
 
         // Iterate through each series and run.
         for (Series s : series) {

--- a/src/arcade/core/command.xml
+++ b/src/arcade/core/command.xml
@@ -1,9 +1,9 @@
 <commands>
-    <position id="ARCADE" help="ARCADE type" />
-    <position id="XML" help="Absolute path to setup XML" />
-    <position id="PATH" help="Absolute path for snapshot JSON" />
-    <switch id="VIS" short="v" long="vis" help="Run with visualization overhead" />
-    <option id="LOADPATH" long="loadpath" help="Path prefix for loaded files" />
-    <switch id="LOADCELLS" short="c" long="cells" help="Load the .CELLS file" />
-    <switch id="LOADLOCATIONS" short="l" long="locations" help="Load the .LOCATIONS file" />
+    <position id="IMPLEMENTATION_TYPE" help="Model implementation type (patch | potts)" />
+    <position id="SETUP_FILE" help="Absolute path to setup file" />
+    <position id="SNAPSHOT_PATH" help="Absolute path for snapshot files" />
+    <switch id="VIS" short="v" long="vis" help="Flag for running with visualization" />
+    <option id="LOAD_PATH" long="loadpath" help="Path prefix for loading snapshots" />
+    <switch id="LOAD_CELLS" short="c" long="cells" help="Load the CELLS snapshot file" />
+    <switch id="LOAD_LOCATIONS" short="l" long="locations" help="Load the LOCATIONS snapshot file" />
 </commands>

--- a/src/arcade/core/sim/input/InputParser.java
+++ b/src/arcade/core/sim/input/InputParser.java
@@ -3,6 +3,7 @@ package arcade.core.sim.input;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import arcade.core.util.Box;
 import arcade.core.util.MiniBox;
 
@@ -237,6 +238,38 @@ public class InputParser {
                     + (shortFlag == null ? "" : String.format(format, "[short]", shortFlag))
                     + (longFlag == null ? "" : String.format(format, "[long]", longFlag));
         }
+    }
+
+    /**
+     * Render help message.
+     *
+     * @param program the command for running the program
+     * @return the help message
+     */
+    public String help(String program) {
+        String usage =
+                allCommands.stream()
+                        .filter(command -> command.type == POSITION)
+                        .map(Command::toUsage)
+                        .collect(Collectors.joining(""));
+
+        String arguments =
+                allCommands.stream()
+                        .filter(command -> command.type == POSITION)
+                        .map(Command::toDescription)
+                        .collect(Collectors.joining(""));
+
+        String options =
+                allCommands.stream()
+                        .filter(command -> command.type != POSITION)
+                        .map(Command::toDescription)
+                        .collect(Collectors.joining(""));
+
+        return String.format("\nUsage:\n  %s%s [options]", program, usage)
+                + String.format("\n  %s (-h | --help)", program)
+                + String.format("\n  %s --version\n", program)
+                + String.format("\nArguments:\n%s", arguments)
+                + String.format("\nOptions:\n%s", options);
     }
 
     /**

--- a/src/arcade/core/sim/input/InputParser.java
+++ b/src/arcade/core/sim/input/InputParser.java
@@ -41,6 +41,9 @@ public class InputParser {
     /** Logger for {@code InputParser}. */
     private static final Logger LOGGER = Logger.getLogger(InputParser.class.getName());
 
+    /** Help message shown when invalid arguments are passed. */
+    private static final String HELP_MESSAGE = " Run with -h or --help for usage instructions.";
+
     /** ID for position commands. */
     static final int POSITION = 0;
 
@@ -286,7 +289,7 @@ public class InputParser {
         parseArguments(args);
 
         if (positionIndex != positionCommands.size()) {
-            LOGGER.severe("missing position arguments");
+            LOGGER.severe("Missing positional arguments." + HELP_MESSAGE);
             throw new IllegalArgumentException();
         } else {
             LOGGER.config("successfully parsed commands\n\n" + parsed.toString());
@@ -342,6 +345,11 @@ public class InputParser {
      * @return the next argument index
      */
     int parseFlaggedArgument(String[] args, int index, Command cmd) {
+        if (cmd == null) {
+            LOGGER.severe("Invalid command [ " + args[index] + " ]." + HELP_MESSAGE);
+            throw new IllegalArgumentException();
+        }
+
         if (cmd.type == SWITCH) {
             parsed.put(cmd.id, "");
         } else {

--- a/src/arcade/core/sim/input/InputParser.java
+++ b/src/arcade/core/sim/input/InputParser.java
@@ -184,6 +184,46 @@ public class InputParser {
         }
 
         /**
+         * Convert command to usage.
+         *
+         * <p>Usage depends on the command type.
+         *
+         * @return the command usage
+         */
+        public String toUsage() {
+            if (type == POSITION) {
+                return String.format(" %s", id);
+            } else if (type == OPTION) {
+                return String.format(" [--%s <%s>]", longFlag, id.toLowerCase());
+            } else if (type == SWITCH) {
+                return String.format(" [(-%s|--%s)]", shortFlag, longFlag);
+            } else {
+                return "";
+            }
+        }
+
+        /**
+         * Convert command to description.
+         *
+         * <p>Description depends on the command type.
+         *
+         * @return the command description.
+         */
+        public String toDescription() {
+            String description = "";
+
+            if (type == POSITION) {
+                description = id;
+            } else if (type == OPTION) {
+                description = String.format("--%s <%s>", longFlag, id.toLowerCase());
+            } else if (type == SWITCH) {
+                description = String.format("-%s --%s", shortFlag, longFlag);
+            }
+
+            return String.format("  %-23s  %s.\n", description, help);
+        }
+
+        /**
          * Formats command as a string.
          *
          * @return a string representation of the command

--- a/test/arcade/core/ARCADETest.java
+++ b/test/arcade/core/ARCADETest.java
@@ -20,9 +20,9 @@ import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
 
 public class ARCADETest {
-    private static final String XML = randomString();
+    private static final String SETUP_FILE = randomString();
 
-    private static final String PATH = randomString();
+    private static final String SNAPSHOT_PATH = randomString();
 
     private static final String IMPLEMENTATION = randomString();
 
@@ -61,7 +61,7 @@ public class ARCADETest {
                                     return seriesList;
                                 })
                         .when(builder)
-                        .build(eq(XML));
+                        .build(eq(SETUP_FILE));
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -157,8 +157,8 @@ public class ARCADETest {
     public void buildSeries_noVis_returnsList() throws IOException, SAXException {
         Box parameters = new Box();
         MiniBox settings = new MiniBox();
-        settings.put("XML", XML);
-        settings.put("PATH", PATH);
+        settings.put("SETUP_FILE", SETUP_FILE);
+        settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH);
 
         ARCADE arcade = new MockARCADE();
         ArrayList<Series> series = arcade.buildSeries(parameters, settings);
@@ -171,8 +171,8 @@ public class ARCADETest {
     public void buildSeries_withVis_returnsList() throws IOException, SAXException {
         Box parameters = new Box();
         MiniBox settings = new MiniBox();
-        settings.put("XML", XML);
-        settings.put("PATH", PATH);
+        settings.put("SETUP_FILE", SETUP_FILE);
+        settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH);
         settings.put("VIS", "");
 
         ARCADE arcade = new MockARCADE();
@@ -186,8 +186,8 @@ public class ARCADETest {
     public void buildSeries_withPathSeparator_returnsList() throws IOException, SAXException {
         Box parameters = new Box();
         MiniBox settings = new MiniBox();
-        settings.put("XML", XML);
-        settings.put("PATH", PATH + "/");
+        settings.put("SETUP_FILE", SETUP_FILE);
+        settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH + "/");
 
         ARCADE arcade = new MockARCADE();
         ArrayList<Series> series = arcade.buildSeries(parameters, settings);
@@ -327,7 +327,7 @@ public class ARCADETest {
         series.add(mock(Series.class));
 
         MiniBox settings = new MiniBox();
-        settings.put("LOADCELLS", "");
+        settings.put("LOAD_CELLS", "");
 
         ARCADE arcade = new MockARCADE();
         arcade.runSeries(series, settings);
@@ -342,7 +342,7 @@ public class ARCADETest {
         series.add(mock(Series.class));
 
         MiniBox settings = new MiniBox();
-        settings.put("LOADLOCATIONS", "");
+        settings.put("LOAD_LOCATIONS", "");
 
         ARCADE arcade = new MockARCADE();
         arcade.runSeries(series, settings);
@@ -357,8 +357,8 @@ public class ARCADETest {
         series.add(mock(Series.class));
 
         MiniBox settings = new MiniBox();
-        settings.put("LOADCELLS", "");
-        settings.put("LOADLOCATIONS", "");
+        settings.put("LOAD_CELLS", "");
+        settings.put("LOAD_LOCATIONS", "");
 
         ARCADE arcade = new MockARCADE();
         arcade.runSeries(series, settings);

--- a/test/arcade/core/ARCADETest.java
+++ b/test/arcade/core/ARCADETest.java
@@ -108,7 +108,7 @@ public class ARCADETest {
         ARCADE arcade = new MockARCADE(path);
         Box commands = arcade.loadCommands(IMPLEMENTATION);
 
-        assertEquals("POSITION", commands.getTag("ARCADE"));
+        assertEquals("POSITION", commands.getTag("IMPLEMENTATION_TYPE"));
         assertEquals("SWITCH", commands.getTag("MOCK"));
     }
 

--- a/test/arcade/core/sim/input/InputParserTest.java
+++ b/test/arcade/core/sim/input/InputParserTest.java
@@ -238,10 +238,8 @@ public class InputParserTest {
                 () -> {
                     Box box = new Box();
                     box.addTag(COMMAND_ID_1, "POSITION");
-
                     InputParser parser = new InputParser(box);
-                    MiniBox parsed = parser.parse(new String[] {});
-                    assertTrue(parsed.compare(new MiniBox()));
+                    parser.parse(new String[] {});
                 });
     }
 
@@ -446,6 +444,17 @@ public class InputParserTest {
         int newIndex = parser.parsePositionArgument(arguments, index);
 
         assertEquals(index + 1, newIndex);
+    }
+
+    @Test
+    public void parseFlaggedArgument_nullCommand_throwsException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    Box box = new Box();
+                    InputParser parser = new InputParser(box);
+                    parser.parseFlaggedArgument(new String[] {""}, 0, null);
+                });
     }
 
     @Test


### PR DESCRIPTION
Updated command line to support `--version` (which prints the version) and `-h/--help` (which prints the help message listing usage, arguments, and options (following [docopt](http://docopt.org) conventions).

## Summary of changes

- Add `--version` command to print version
- Add `-h` and `--help` commands to print help message
- Update command names and help messages for clarity 
- Update `Command` class (in `InputParser`) to support docopt-style usage and descriptions

## Steps to verify

1. Build jar
2. Run `java -jar arcade.jar --version` (displays version)
3. Run `java -jar arcade.jar -h` (displays help message)
4. Run `java -jar arcade.jar --help` (displays help message)

Current setup is that including `-h` or `--help` anywhere in the command will print the help message. Alternative would be to support only the options shown in step 3 and step 4 (putting the help command anywhere else would throw an error). Not sure which is more intuitive.
