### PR TITLE
[CARCADE Refactor into V3] Adding CART Metabolism Class

### DIFF
--- a/src/arcade/patch/agent/process/PatchProcessMetabolism.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolism.java
@@ -217,6 +217,8 @@ public abstract class PatchProcessMetabolism extends PatchProcess {
                 return new PatchProcessMetabolismMedium(cell);
             case "COMPLEX":
                 return new PatchProcessMetabolismComplex(cell);
+            case "CART":
+                return new PatchProcessMetabolismCART(cell);
             default:
                 return null;
         }

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismCART.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismCART.java
@@ -1,0 +1,307 @@
+package arcade.patch.agent.process;
+
+import java.util.Arrays;
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.process.Process;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.util.PatchEnums.Domain;
+
+public class PatchProcessMetabolismCART extends PatchProcessMetabolism {
+
+    /** ID for pyruvate */
+    public static final int PYRUVATE = 1;
+
+    /** Flag indicating T-cell's antigen induced activation state. */
+    private boolean active;
+
+    /** Metabolic preference for glycolysis over oxidative phosphorylation */
+    private final double metaPref;
+
+    /** Minimal cell mass */
+    private final double fracMass;
+
+    /** Fraction of internal glucose/pyruvate converted to mass. */
+    private final double conversionFraction;
+
+    /** Preference for glucose over pyruvate for mass */
+    private final double ratioGlucosePyruvate;
+
+    /** Rate of lactate production */
+    private final double lactateRate;
+
+    /** Rate of autophagy */
+    private final double autophagyRate;
+
+    /** Rate of glucose uptake */
+    private final double glucUptakeRate;
+
+    /** Max incrase in metabolic preference for glycolysis over oxidative phosphorylation */
+    private final double metabolicPreference_IL2;
+
+    /** Increase in rate of glucose uptake due antigen-induced activation */
+    private final double metabolicPreference_active;
+
+    /** Max increase in rate of glucose uptake due to IL-2 bound to surface */
+    private final double glucoseUptakeRate_IL2;
+
+    /** Increase in rate of glucose uptake due to antigen-induced activation. */
+    private final double glucoseUptakeRate_active;
+
+    /** Increase in fraction of glucose used for cell mass due to antigen-induced activation. */
+    private final double minimumMassFraction_active;
+
+    /** Time delay for changes in metabolism. */
+    private final int timeDelay;
+
+    /** Metabolic preference value after stepping through the process. For testing purposes only */
+    private double finalMetabolicPreference;
+
+    /** Glucose uptake rate value after stepping through the process. For testing purposes only */
+    private double finalGlucoseUptakeRate;
+
+    /** Minimum mass fraction value after stepping through the process. For testing purposes only */
+    private double finalMinimumMassFraction;
+
+    /**
+     * Creates a metabolism {@link PatchProcess} for the given cell.
+     *
+     * <p>Process parameters are specific for the cell population. Loaded parameters include:
+     *
+     * <ul>
+     *   <li>{@code METABOLIC_PREFERENCE} = preference for glycolysis over oxidative phosphorylation
+     *   <li>{@code CONVERSION_FRACTION} = fraction of internal glucose / pyruvate converted to mass
+     *   <li>{@code MINIMUM_MASS_FRACTION} = minimum viable cell mass fraction
+     *   <li>{@code RATIO_GLUCOSE_PYRUVATE} = preference for glucose over pyruvate for mass
+     *   <li>{@code LACTATE_RATE} = rate of lactate production
+     *   <li>{@code AUTOPHAGY_RATE} = rate of autophagy
+     *   <li>{@code GLUCOSE_UPTAKE_RATE} = rate of glucose uptake
+     *   <li>{@code INITIAL_GLUCOSE_CONCENTRATION} = initial cell internal glucose concentration
+     * </ul>
+     *
+     * The process starts with energy at zero and assumes a constant ratio between mass and volume
+     * (through density).
+     *
+     * @param cell the {@link PatchCell} the process is associated with
+     */
+    public PatchProcessMetabolismCART(PatchCell cell) {
+        super(cell);
+        // Mapping for internal concentration access.
+        String[] intNames = new String[2];
+        intNames[GLUCOSE] = "glucose";
+        intNames[PYRUVATE] = "pyruvate";
+        names = Arrays.asList(intNames);
+
+        // Set loaded parameters.
+        // TODO: pull metabolic preference from distribution
+        Parameters parameters = cell.getParameters();
+        metaPref = parameters.getDouble("metabolism/METABOLIC_PREFERENCE");
+        conversionFraction = parameters.getDouble("metabolism/CONVERSION_FRACTION");
+        fracMass = parameters.getDouble("metabolism/MINIMUM_MASS_FRACTION");
+        ratioGlucosePyruvate = parameters.getDouble("metabolism/RATIO_GLUCOSE_PYRUVATE");
+        lactateRate = parameters.getDouble("metabolism/LACTATE_RATE");
+        autophagyRate = parameters.getDouble("metabolism/AUTOPHAGY_RATE");
+        glucUptakeRate = parameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE");
+
+        metabolicPreference_IL2 = parameters.getDouble("metabolism/META_PREF_IL2");
+        metabolicPreference_active = parameters.getDouble("metabolism/META_PREF_ACTIVE");
+        glucoseUptakeRate_IL2 = parameters.getDouble("metabolism/GLUC_UPTAKE_RATE_IL2");
+        glucoseUptakeRate_active = parameters.getDouble("metabolism/GLUC_UPTAKE_RATE_ACTIVE");
+        minimumMassFraction_active = parameters.getDouble("metabolism/FRAC_MASS_ACTIVE");
+        timeDelay = (int) parameters.getDouble("metabolism/META_SWITCH_DELAY");
+
+        // Initial internal concentrations.
+        intAmts = new double[2];
+        intAmts[GLUCOSE] =
+                parameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION") * volume;
+        intAmts[PYRUVATE] = intAmts[GLUCOSE] * PYRU_PER_GLUC;
+    }
+
+    @Override
+    void stepProcess(MersenneTwisterFast random, Simulation sim) {
+        double glucInt = intAmts[GLUCOSE]; // [fmol]
+        double pyruInt = intAmts[PYRUVATE]; // [fmol]
+        double glucExt = extAmts[GLUCOSE]; // [fmol]
+        double oxyExt = extAmts[OXYGEN]; // [fmol]
+
+        PatchProcessInflammation inflammation =
+                (PatchProcessInflammation) cell.getProcess(Domain.INFLAMMATION);
+        double[] boundArray = inflammation.boundArray; // [molecules]
+        int IL2Ticker = inflammation.IL2Ticker;
+        double IL2ReceptorsTotal = inflammation.IL2_RECEPTORS;
+
+        int metaIndex = (IL2Ticker % boundArray.length) - timeDelay;
+        if (metaIndex < 0) {
+            metaIndex += boundArray.length;
+        }
+        double priorIL2meta = boundArray[metaIndex];
+
+        // Calculate metabolic preference and glucose uptake rate
+        // as a function of base values plus impact of IL-2 bound to surface.
+        double metabolicPreference =
+                metaPref + (metabolicPreference_IL2 * (priorIL2meta / IL2ReceptorsTotal));
+        double glucoseUptakeRate =
+                glucUptakeRate + (glucoseUptakeRate_IL2 * (priorIL2meta / IL2ReceptorsTotal));
+        double minimumMassFraction = fracMass;
+
+        // Check active status
+        active = ((PatchCellCART) cell).getActivationStatus();
+        double activeTicker = inflammation.activeTicker;
+
+        // Add metabolic preference and glucose uptake rate depdendent on
+        // antigen-induced cell activation if cell is activated.
+        if (active && activeTicker >= timeDelay) {
+            metabolicPreference += metabolicPreference_active;
+            glucoseUptakeRate += glucoseUptakeRate_active;
+            minimumMassFraction += minimumMassFraction_active;
+        }
+
+        // Take up glucose from environment, relative to glucose gradient.
+        // If agent shares location with other agents, occupied area for
+        // calculating surface area is limited by the number of neighbors.
+        double area = location.getArea() * f;
+        double surfaceArea = area * 2 + (volume / area) * location.getPerimeter(f);
+        double glucGrad = (glucExt / location.getVolume()) - (glucInt / volume);
+        glucGrad *= glucGrad < 1E-10 ? 0 : 1;
+        double glucUptake = glucoseUptakeRate * surfaceArea * glucGrad;
+        glucInt += glucUptake;
+
+        // Determine energy requirement given current type in terms of glucose.
+        // Additional energy needed for cell that is migrating or proliferating.
+        // Arrays indicate oxidative phosphorylation (0) and glycolysis (1).
+        double[] energyGen = {0, 0};
+        double glucReq = metabolicPreference * energyReq / ENERGY_FROM_GLYC;
+        double pyruReq = (1 - metabolicPreference) * energyReq / ENERGY_FROM_OXPHOS;
+
+        // Calculate oxygen required and take up from environment.
+        double oxyReq = pyruReq * OXY_PER_PYRU;
+        double oxyUptake = Math.min(oxyExt, oxyReq);
+        oxyUptake *= oxyUptake < 1E-10 ? 0 : 1;
+
+        // Perform oxidative phosphorylation using internal pyruvate.
+        double oxyUptakeInPyru = oxyUptake / OXY_PER_PYRU;
+        if (pyruInt > oxyUptakeInPyru) {
+            energyGen[0] += oxyUptakeInPyru * ENERGY_FROM_OXPHOS; // add energy
+            pyruInt -= oxyUptakeInPyru; // use up internal pyruvate
+        } else {
+            energyGen[0] += pyruInt * ENERGY_FROM_OXPHOS; // add energy
+            oxyUptake = pyruInt * OXY_PER_PYRU; // return unused oxygen
+            pyruInt = 0.0; // use up internal pyruvate
+        }
+
+        // Check if more glucose needs to be diverted to compensate for energy
+        // deficit (from not enough oxygen) and is available.
+        if (energy <= 0 && glucInt > 0) {
+            double glucNeeded = -(energy - energyCons + energyGen[0]) / ENERGY_FROM_GLYC;
+            glucReq = Math.max(glucReq, glucNeeded);
+        }
+
+        // Perform glycolysis. Internal glucose is converted to internal pyruvate
+        // which is used in oxidative phosphorylation or to increase mass.
+        if (glucInt > glucReq) {
+            energyGen[1] += glucReq * ENERGY_FROM_GLYC;
+            pyruInt += glucReq * PYRU_PER_GLUC; // increase internal pyruvate
+            glucInt -= glucReq; // use up internal glucose
+        } else {
+            energyGen[1] += glucInt * ENERGY_FROM_GLYC;
+            pyruInt += glucInt * PYRU_PER_GLUC; // increase internal pyruvate
+            glucInt = 0.0; // use up all internal glucose
+        }
+
+        // Update energy.
+        energy += energyGen[0];
+        energy += energyGen[1];
+        energy -= energyCons;
+        energy *= Math.abs(energy) < 1E-10 ? 0 : 1;
+
+        // Increase mass if (i) dividing and less than double mass or (ii)
+        // below critical mass for maintenance.
+        if ((energy >= 0 && isProliferative && mass < 2 * critMass)
+                || (energy >= 0 && mass < 0.99 * critMass)) {
+            mass +=
+                    conversionFraction
+                            * (ratioGlucosePyruvate * glucInt
+                                    + (1 - ratioGlucosePyruvate) * pyruInt / PYRU_PER_GLUC)
+                            / ratioGlucoseBiomass;
+            glucInt *= (1 - conversionFraction * ratioGlucosePyruvate);
+            pyruInt *= (1 - conversionFraction * (1 - ratioGlucosePyruvate));
+        }
+
+        // Decrease mass through autophagy if (i) negative energy indicating
+        // not enough nutrients or (ii) above critical mass for maintenance
+        if ((energy < 0 && mass > minimumMassFraction * critMass)
+                || (energy >= 0 && mass > 1.01 * critMass && !isProliferative)) {
+            mass -= autophagyRate;
+            glucInt += autophagyRate * ratioGlucoseBiomass;
+        }
+
+        // Update volume based on changes in mass.
+        volume = mass / cellDensity;
+
+        // Convert internal pyruvate to lactate (i.e. remove pyruvate).
+        pyruInt -= lactateRate * pyruInt;
+
+        // Reset values.
+        intAmts[GLUCOSE] = glucInt;
+        upAmts[GLUCOSE] = glucUptake;
+        upAmts[OXYGEN] = oxyUptake;
+        intAmts[PYRUVATE] = pyruInt;
+
+        // Set final metabolic preference for testing
+        finalMetabolicPreference = metabolicPreference;
+        // Set final glucose uptake rate for testing
+        finalGlucoseUptakeRate = glucoseUptakeRate;
+        // Set final min mass fraction for testing
+        finalMinimumMassFraction = minimumMassFraction;
+    }
+
+    @Override
+    public void update(Process process) {
+        PatchProcessMetabolismCART metabolism = (PatchProcessMetabolismCART) process;
+        double split = this.cell.getVolume() / this.volume;
+
+        // Update daughter cell metabolism as fraction of parent.
+        this.energy = metabolism.energy * f;
+        this.intAmts[GLUCOSE] = metabolism.intAmts[GLUCOSE] * split;
+        this.intAmts[PYRUVATE] = metabolism.intAmts[PYRUVATE] * split;
+
+        // Update parent cell with remaining fraction.
+        metabolism.energy *= (1 - split);
+        metabolism.intAmts[GLUCOSE] *= (1 - split);
+        metabolism.intAmts[PYRUVATE] *= (1 - split);
+        metabolism.volume *= (1 - split);
+        metabolism.mass *= (1 - split);
+    }
+
+    /**
+     * Returns final value of metabolic preference after stepping process Exists for testing
+     * purposes only
+     *
+     * @return final value of the metabolic preference
+     */
+    public double getFinalMetabolicPreference() {
+        return finalMetabolicPreference;
+    }
+
+    /**
+     * Returns final value of glucose uptake rate after stepping process Exists for testing purposes
+     * only
+     *
+     * @return final value of glucose uptake rate
+     */
+    public double getFinalGlucoseUptakeRate() {
+        return finalGlucoseUptakeRate;
+    }
+
+    /**
+     * Returns final value of minimum mass fraction after stepping process Exists for testing
+     * purposes only
+     *
+     * @return final value of min mass fraction
+     */
+    public double getFinalMinimumMassFraction() {
+        return finalMinimumMassFraction;
+    }
+}

--- a/src/arcade/patch/agent/process/PatchProcessMetabolismCART.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolismCART.java
@@ -9,6 +9,41 @@ import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.util.PatchEnums.Domain;
 
+/**
+ * Extension of {@link PatchProcessMetabolism} for CAR T-cell metabolism.
+ * <p>
+ * {@code MetabolismCART} is adapted from {@code MetabolismComplex} and thus
+ * this module explicitly includes pyruvate intermediate between
+ * glycolysis and oxidative phosphorylation and glucose uptake is based on cell
+ * surface area.
+ * Metabolic preference between glycolysis and oxidative phosphorylation is
+ * controlled by the {@code META_PREF} parameter.
+ * The glycolysis pathway will compensate if there is not enough oxygen to meet
+ * energetic requirements through the oxidative phosphorylation pathway given
+ * the specified metabolic preference.
+ * The preference for glycolysis can be further increased due to IL-2 bound to the
+ * cell surface by a maximum of {@code META_PREF_IL2} parameter and by the T-cell's
+ * antigen-induced activation state by the {@code META_PREF_ACTIVE} parameter.
+ * The antigen-induced activation state can also increase the rate of uptake of
+ * glucose by the {@code GLUC_UPTAKE_RATE_ACTIVE} parameter and the fraction of
+ * glucose being used to make cell mass by the {@code FRAC_MASS_ACTIVE} parameter.
+ * The amount of IL-2 bound to the cell surface can also incrase the uptake rate of
+ * glucose by a max of the {@code GLUC_UPTAKE_RATE_IL2} parameter.
+ * <p>
+ * {@code PatchProcessMetabolismCART} will increase cell mass (using specified fractions
+ * of internal glucose and pyruvate) if:
+ * <ul>
+ *     <li>cell is dividing and less than double in size</li>
+ *     <li>cell is below critical mass for maintenance</li>
+ * </ul>
+ * {@code PatchProcessMetabolismCART } will decrease cell mass if:
+ * <ul>
+ *     <li>cell has negative energy levels indicating insufficient nutrients</li>
+ *     <li>cell is above critical mass for maintenance</li>
+ * </ul>
+ * <p>
+ * Internal pyruvate is removed through conversion to lactate.
+ */
 public class PatchProcessMetabolismCART extends PatchProcessMetabolism {
 
     /** ID for pyruvate */

--- a/test/arcade/patch/agent/process/PatchProcessMetabolismCARTTest.java
+++ b/test/arcade/patch/agent/process/PatchProcessMetabolismCARTTest.java
@@ -1,0 +1,347 @@
+package arcade.patch.agent.process;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+
+public class PatchProcessMetabolismCARTTest {
+
+    private PatchCellCART mockCell;
+    private Parameters mockParameters;
+    private PatchProcessMetabolismCART metabolism;
+    private PatchLocation mockLocation;
+    private double cellVolume;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = mock(PatchCellCART.class);
+        mockParameters = mock(Parameters.class);
+        mockLocation = mock(PatchLocation.class);
+
+        when(mockCell.getParameters()).thenReturn(mockParameters);
+        when(mockParameters.getDouble(anyString())).thenReturn(1.0);
+        when(mockCell.getLocation()).thenReturn(mockLocation);
+        cellVolume = randomDoubleBetween(165, 180);
+        when(mockCell.getVolume()).thenReturn(cellVolume);
+        when(mockLocation.getPerimeter(anyDouble()))
+                .thenReturn(randomDoubleBetween(0, 1.0) * 6 * 30 / Math.sqrt(3));
+        when(mockLocation.getArea()).thenReturn(3.0 / 2.0 / Math.sqrt(3.0) * 30 * 30);
+        when(mockLocation.getVolume()).thenReturn(3.0 / 2.0 / Math.sqrt(3.0) * 30 * 30 * 8.7);
+    }
+
+    @Test
+    public void testConstructorInitializesFields()
+            throws NoSuchFieldException, IllegalAccessException {
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        assertNotNull(metabolism);
+
+        Field metaPrefField = PatchProcessMetabolismCART.class.getDeclaredField("metaPref");
+        metaPrefField.setAccessible(true);
+        assertEquals(1.0, metaPrefField.get(metabolism));
+
+        Field conversionFractionField =
+                PatchProcessMetabolismCART.class.getDeclaredField("conversionFraction");
+        conversionFractionField.setAccessible(true);
+        assertEquals(1.0, conversionFractionField.get(metabolism));
+
+        Field fracMassField = PatchProcessMetabolismCART.class.getDeclaredField("fracMass");
+        fracMassField.setAccessible(true);
+        assertEquals(1.0, fracMassField.get(metabolism));
+
+        Field ratioGlucosePyruvateField =
+                PatchProcessMetabolismCART.class.getDeclaredField("ratioGlucosePyruvate");
+        ratioGlucosePyruvateField.setAccessible(true);
+        assertEquals(1.0, ratioGlucosePyruvateField.get(metabolism));
+
+        Field lactateRateField = PatchProcessMetabolismCART.class.getDeclaredField("lactateRate");
+        lactateRateField.setAccessible(true);
+        assertEquals(1.0, lactateRateField.get(metabolism));
+
+        Field autophagyRateField =
+                PatchProcessMetabolismCART.class.getDeclaredField("autophagyRate");
+        autophagyRateField.setAccessible(true);
+        assertEquals(1.0, autophagyRateField.get(metabolism));
+
+        Field glucUptakeRateField =
+                PatchProcessMetabolismCART.class.getDeclaredField("glucUptakeRate");
+        glucUptakeRateField.setAccessible(true);
+        assertEquals(1.0, glucUptakeRateField.get(metabolism));
+
+        Field metabolicPreference_IL2Field =
+                PatchProcessMetabolismCART.class.getDeclaredField("metabolicPreference_IL2");
+        metabolicPreference_IL2Field.setAccessible(true);
+        assertEquals(1.0, metabolicPreference_IL2Field.get(metabolism));
+
+        Field metabolicPreference_activeField =
+                PatchProcessMetabolismCART.class.getDeclaredField("metabolicPreference_active");
+        metabolicPreference_activeField.setAccessible(true);
+        assertEquals(1.0, metabolicPreference_activeField.get(metabolism));
+
+        Field glucoseUptakeRate_IL2Field =
+                PatchProcessMetabolismCART.class.getDeclaredField("glucoseUptakeRate_IL2");
+        glucoseUptakeRate_IL2Field.setAccessible(true);
+        assertEquals(1.0, glucoseUptakeRate_IL2Field.get(metabolism));
+
+        Field glucoseUptakeRate_activeField =
+                PatchProcessMetabolismCART.class.getDeclaredField("glucoseUptakeRate_active");
+        glucoseUptakeRate_activeField.setAccessible(true);
+        assertEquals(1.0, glucoseUptakeRate_activeField.get(metabolism));
+
+        Field minimumMassFraction_activeField =
+                PatchProcessMetabolismCART.class.getDeclaredField("minimumMassFraction_active");
+        minimumMassFraction_activeField.setAccessible(true);
+        assertEquals(1.0, minimumMassFraction_activeField.get(metabolism));
+
+        Field timeDelayField = PatchProcessMetabolismCART.class.getDeclaredField("timeDelay");
+        timeDelayField.setAccessible(true);
+        assertEquals(1, timeDelayField.get(metabolism));
+    }
+
+    @Test
+    public void testStepProcess() throws NoSuchFieldException, IllegalAccessException {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+        Field fraction = PatchProcessMetabolism.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(metabolism, 1.0);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        assertTrue(metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE] >= 0);
+        assertTrue(metabolism.intAmts[PatchProcessMetabolismCART.PYRUVATE] >= 0);
+    }
+
+    @Test
+    public void testStepProcessWithZeroInitialGlucose() {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.0);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        assertEquals(0.0, metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE]);
+    }
+
+    @Test
+    public void testStepProcessWithMaxGlucoseConcentration() {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION"))
+                .thenReturn(Double.MAX_VALUE);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        assertTrue(metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE] <= Double.MAX_VALUE);
+    }
+
+    @Test
+    public void testStepProcessWithNegativeGlucoseConcentration() {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(-1.0);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        assertTrue(metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE] >= 0);
+    }
+
+    @Test
+    public void testStepProcessWithZeroOxygenConcentration() {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.extAmts[PatchProcessMetabolismCART.OXYGEN] = 0.0;
+
+        metabolism.stepProcess(random, sim);
+
+        assertEquals(0.0, metabolism.extAmts[PatchProcessMetabolismCART.OXYGEN]);
+    }
+
+    @Test
+    public void testStepProcessWithMaxOxygenConcentration() {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.extAmts[PatchProcessMetabolismCART.OXYGEN] = Double.MAX_VALUE;
+
+        metabolism.stepProcess(random, sim);
+
+        assertTrue(metabolism.extAmts[PatchProcessMetabolismCART.OXYGEN] <= Double.MAX_VALUE);
+    }
+
+    @Test
+    public void testActivatedMetabolicPreference()
+            throws IllegalAccessException, NoSuchFieldException {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        Field activeTicker = PatchProcessInflammation.class.getDeclaredField("activeTicker");
+        activeTicker.setAccessible(true);
+        activeTicker.set(inflammation, 1);
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        double expectedMetabolicPreference = 1.0 + 1.0; // base + active
+        assertEquals(expectedMetabolicPreference, metabolism.getFinalMetabolicPreference());
+    }
+
+    @Test
+    public void testActivatedGlucoseUptakeRate()
+            throws IllegalAccessException, NoSuchFieldException {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        Field activeTicker = PatchProcessInflammation.class.getDeclaredField("activeTicker");
+        activeTicker.setAccessible(true);
+        activeTicker.set(inflammation, 1);
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        double expectedGlucoseUptakeRate = 1.12 + 1.0; // base + active
+        assertEquals(expectedGlucoseUptakeRate, metabolism.getFinalGlucoseUptakeRate());
+    }
+
+    @Test
+    public void testActivatedMinimumMassFraction()
+            throws NoSuchFieldException, IllegalAccessException {
+        // set up metabolism class
+        when(mockParameters.getDouble("metabolism/GLUCOSE_UPTAKE_RATE")).thenReturn(1.12);
+        when(mockParameters.getDouble("metabolism/INITIAL_GLUCOSE_CONCENTRATION")).thenReturn(0.05);
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+
+        // set up simulation
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Simulation sim = mock(Simulation.class);
+
+        // mock inflammation process
+        PatchProcessInflammation inflammation = spy(new PatchProcessInflammationCD4(mockCell));
+        Field activeTicker = PatchProcessInflammation.class.getDeclaredField("activeTicker");
+        activeTicker.setAccessible(true);
+        activeTicker.set(inflammation, 1);
+        when(mockCell.getProcess(any())).thenReturn(inflammation);
+        when(mockCell.getActivationStatus()).thenReturn(true);
+
+        metabolism.stepProcess(random, sim);
+
+        double expectedMinimumMassFraction = 1.0 + 1.0; // base + active
+        assertEquals(expectedMinimumMassFraction, metabolism.getFinalMinimumMassFraction());
+    }
+
+    @Test
+    public void testUpdate() {
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+        PatchProcessMetabolismCART parentProcess = new PatchProcessMetabolismCART(mockCell);
+        parentProcess.intAmts[PatchProcessMetabolismCART.GLUCOSE] = 100;
+        when(mockCell.getVolume()).thenReturn(cellVolume / 2);
+
+        metabolism.update(parentProcess);
+
+        assertEquals(50, metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE]);
+        assertEquals(50, parentProcess.intAmts[PatchProcessMetabolismCART.GLUCOSE]);
+    }
+
+    @Test
+    public void testUpdateZeroVolumeParent() {
+        metabolism = new PatchProcessMetabolismCART(mockCell);
+        PatchProcessMetabolismCART parentProcess = new PatchProcessMetabolismCART(mockCell);
+        parentProcess.intAmts[PatchProcessMetabolismCART.GLUCOSE] = 100;
+        when(mockCell.getVolume()).thenReturn(0.0);
+
+        metabolism.update(parentProcess);
+
+        assertEquals(0, metabolism.intAmts[PatchProcessMetabolismCART.GLUCOSE]);
+        assertEquals(100, parentProcess.intAmts[PatchProcessMetabolismCART.GLUCOSE]);
+    }
+}


### PR DESCRIPTION
Partly resolves #40 

_Estimated size: Medium_

Change Descriptions:

`PatchProcess Metabolism` class:
- added CART option in make() method to allow for new metabolism type

`PatchProcessMetabolismCART` class:
- As implemented in original CARCADE model
- There is an up-regulated glucose uptake rate and metabolic preference depending on the activation status of the cell. The activation status of the cell is determined by the inflammation process. 

`PatchProcessMetabolismCARTTest` class:
- added unit tests to verify functionality of the CART metabolism class

------------------------------
## Reference to other PRs

In an effort to not make this more of an ungodly PR than it already is, I broke the changes up into chunks. I've linked the other PRs below for ease of referencing other classes:

### Parameters (#146)
- parameter.patch.xml
### CART Agents and associated classes (#145)
- PatchCellCART, PatchCellCARTCD4, PatchCellCARTCD8 
- PatchCellContainer
- PatchGrid
- PatchModuleProliferation
- PatchEnums
### Reset Action (#144)
- PatchActionReset
### Kill Action (#143)
- PatchActionKill
### Inflammation Modules (#142)
- PatchProcessInflammation
- PatchProcessInflammationCD4
- PatchProcessInflammationCD8
### Metabolism Modules (#141)
- PatchProcessMetabolism
- PatchProcessMetabolismCART
### Treat Action (#140)
- PatchActionTreat
- PatchSimulationHex
- PatchSimulationRect
### Patch Cell Classes (#139)
- PatchCell
- PatchCellTissue
- PatchCellCancer