### PR TITLE
[CARCADE Refactor into V3] Adding Inflammation Modules

### DIFF
--- a/src/arcade/patch/agent/process/PatchProcessInflammation.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammation.java
@@ -1,0 +1,326 @@
+package arcade.patch.agent.process;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import ec.util.MersenneTwisterFast;
+import arcade.core.env.location.Location;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.core.util.Solver;
+import arcade.core.util.Solver.Equations;
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.lattice.PatchLattice;
+
+/**
+ * Implementation of {@link Process} for inflammation type modules in which IL-2 is taken up and
+ * cytotoxic/stimulatory functions are modified.
+ *
+ * <p>The {@code Inflammation} module represents an 8-component signaling network.
+ */
+public abstract class PatchProcessInflammation extends PatchProcess {
+
+    /** Number of components in signaling network */
+    protected static final int NUM_COMPONENTS = 8;
+
+    /** ID for IL-2, bound total */
+    protected static final int IL2_INT_TOTAL = 0;
+
+    /** ID for IL-2, external */
+    protected static final int IL2_EXT = 1;
+
+    /** ID for IL-2 receptors, total between both two and three chain complex */
+    protected static final int IL2R_TOTAL = 2;
+
+    /** ID for two-chain IL-2 receptor complex */
+    protected static final int IL2Rbg = 3;
+
+    /** ID for three-chain IL-2 receptor complex */
+    protected static final int IL2Rbga = 4;
+
+    /** ID for IL-2-two-chain IL-2 receptor complex */
+    protected static final int IL2_IL2Rbg = 5;
+
+    /** ID for IL-2-three-chain IL-2 receptor complex */
+    protected static final int IL2_IL2Rbga = 6;
+
+    /** ID for granzyme, internal */
+    protected static final int GRANZYME = 7;
+
+    /** Number of steps per second to take in ODE */
+    private static final double STEP_DIVIDER = 3.0;
+
+    /**
+     * Rate of conversion of IL-2R two-chain complex to IL-2R three chain complex [/sec/step
+     * divider]
+     */
+    private static final double K_CONVERT = 1e-3 / STEP_DIVIDER;
+
+    /**
+     * Rate of recycling of receptor complexes back to IL-2 receptor two chain complex [/sec/step
+     * divider]
+     */
+    private static final double K_REC = 1e-5 / STEP_DIVIDER;
+
+    /** Rate of IL-2 binding to two-chain IL-2 receptor complex [um^3/molecules IL-2/min] */
+    private double IL2_BINDING_ON_RATE_MIN = 3.8193E-2;
+
+    /** Rate of IL-2 binding to three-chain IL-2 receptor complex [um^3/molecules IL-2/min] */
+    private double IL2_BINDING_ON_RATE_MAX = 3.155;
+
+    /** Rate of unbinding of IL-2 from two- or three- chain IL-2 receptor complex [/min] */
+    private double IL2_BINDING_OFF_RATE = 0.015;
+
+    /** Step size for module (in seconds) */
+    static final double STEP_SIZE = 1.0 / STEP_DIVIDER;
+
+    /** Location of cell */
+    protected Location loc;
+
+    /** Cell the module is associated with */
+    protected PatchCellCART c;
+
+    /** Cell population index */
+    protected int pop;
+
+    /** List of internal names */
+    protected List<String> names;
+
+    /** List of amounts of each species */
+    protected double[] amts;
+
+    /** External IL-2 [molecules] */
+    protected double extIL2;
+
+    /** Shell around cell volume fraction */
+    protected double f;
+
+    /** Volume of cell [um<sup>3</sup>] */
+    protected double volume;
+
+    /** Flag marking if cell is activated via antigen-induced activation */
+    protected boolean active;
+
+    /** Time since cell first bound IL-2 */
+    protected int IL2Ticker;
+
+    /** Time since cell became activated via antigen-induced activation */
+    protected int activeTicker;
+
+    /** List of amounts of IL-2 bound to cell at previous time points */
+    protected double[] boundArray;
+
+    /** Distance outward from surface a cell can sense */
+    protected final double SHELL_THICKNESS;
+
+    /** Total 2-complex receptors */
+    protected final double IL2_RECEPTORS;
+
+    /**
+     * Creates an {@code Inflammation} module for the given {@link PatchCellCART}.
+     *
+     * <p>Module parameters are specific for the cell population. The module starts with no IL-2
+     * bound and no three-chain receptors. Daughter cells split amounts of bound IL-2 and
+     * three-chain receptors upon dividing.
+     *
+     * @param c the {@link PatchCellCART} the module is associated with
+     */
+    public PatchProcessInflammation(PatchCellCART c) {
+        super(c);
+        // Initialize module.
+        this.loc = c.getLocation();
+        this.c = c;
+        this.pop = c.getPop();
+        this.volume = c.getVolume();
+        this.IL2Ticker = 0;
+        this.activeTicker = 0;
+
+        // Set parameters.
+        Parameters parameters = cell.getParameters();
+        this.SHELL_THICKNESS = parameters.getDouble("inflammation/SHELL_THICKNESS");
+        this.IL2_RECEPTORS = parameters.getDouble("inflammation/IL2_RECEPTORS");
+        this.IL2_BINDING_ON_RATE_MIN = parameters.getDouble("inflammation/IL2_BINDING_ON_RATE_MIN");
+        this.IL2_BINDING_ON_RATE_MAX = parameters.getDouble("inflammation/IL2_BINDING_ON_RATE_MAX");
+        this.IL2_BINDING_OFF_RATE = parameters.getDouble("inflammation/IL2_BINDING_OFF_RATE");
+
+        extIL2 = 0;
+
+        // Initial amounts of each species, all in molecules/cell.
+        amts = new double[NUM_COMPONENTS];
+        amts[IL2_INT_TOTAL] = 0;
+        amts[IL2R_TOTAL] = IL2_RECEPTORS;
+        amts[IL2Rbg] = IL2_RECEPTORS;
+        amts[IL2Rbga] = 0;
+        amts[IL2_IL2Rbg] = 0;
+        amts[IL2_IL2Rbga] = 0;
+
+        // Molecule names.
+        names = new ArrayList<String>();
+        names.add(IL2_INT_TOTAL, "IL-2");
+        names.add(IL2_EXT, "external_IL-2");
+        names.add(IL2R_TOTAL, "IL2R_total");
+        names.add(IL2Rbg, "IL2R_two_chain_complex");
+        names.add(IL2Rbga, "IL2R_three_chain_complex");
+        names.add(IL2_IL2Rbg, "IL-2_IL2R_two_chain_complex");
+        names.add(IL2_IL2Rbga, "IL-2_IL2R_three_chain_complex");
+
+        // Initialize prior IL2 array.
+        this.boundArray = new double[180];
+    }
+
+    /** System of ODEs for network */
+    Equations dydt =
+            (Equations & Serializable)
+                    (t, y) -> {
+                        double[] dydt = new double[NUM_COMPONENTS];
+
+                        double kon_2 =
+                                IL2_BINDING_ON_RATE_MIN / loc.getVolume() / 60 / STEP_DIVIDER;
+                        double kon_3 =
+                                IL2_BINDING_ON_RATE_MAX / loc.getVolume() / 60 / STEP_DIVIDER;
+                        double koff = IL2_BINDING_OFF_RATE / 60 / STEP_DIVIDER;
+
+                        dydt[IL2_EXT] =
+                                koff * y[IL2_IL2Rbg]
+                                        + koff * y[IL2_IL2Rbga]
+                                        - kon_2 * y[IL2Rbg] * y[IL2_EXT]
+                                        - kon_3 * y[IL2Rbga] * y[IL2_EXT];
+                        dydt[IL2Rbg] =
+                                koff * y[IL2_IL2Rbg]
+                                        - kon_2 * y[IL2Rbg] * y[IL2_EXT]
+                                        - K_CONVERT * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga]) * y[IL2Rbg]
+                                        + K_REC * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga] + y[IL2Rbga]);
+                        dydt[IL2Rbga] =
+                                koff * y[IL2_IL2Rbga]
+                                        - kon_3 * y[IL2Rbga] * y[IL2_EXT]
+                                        + K_CONVERT * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga]) * y[IL2Rbg]
+                                        - K_REC * y[IL2Rbga];
+                        dydt[IL2_IL2Rbg] =
+                                kon_2 * y[IL2Rbg] * y[IL2_EXT]
+                                        - koff * y[IL2_IL2Rbg]
+                                        - K_CONVERT
+                                                * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga])
+                                                * y[IL2_IL2Rbg]
+                                        - K_REC * y[IL2_IL2Rbg];
+                        dydt[IL2_IL2Rbga] =
+                                kon_3 * y[IL2Rbga] * y[IL2_EXT]
+                                        - koff * y[IL2_IL2Rbga]
+                                        + K_CONVERT
+                                                * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga])
+                                                * y[IL2_IL2Rbg]
+                                        - K_REC * y[IL2_IL2Rbga];
+                        dydt[IL2_INT_TOTAL] =
+                                kon_2 * y[IL2Rbg] * y[IL2_EXT]
+                                        - koff * y[IL2_IL2Rbg]
+                                        - K_CONVERT
+                                                * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga])
+                                                * y[IL2_IL2Rbg]
+                                        - K_REC * y[IL2_IL2Rbg]
+                                        + kon_3 * y[IL2Rbga] * y[IL2_EXT]
+                                        - koff * y[IL2_IL2Rbga]
+                                        + K_CONVERT
+                                                * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga])
+                                                * y[IL2_IL2Rbg]
+                                        - K_REC * y[IL2_IL2Rbga];
+                        dydt[IL2R_TOTAL] =
+                                koff * y[IL2_IL2Rbg]
+                                        - kon_2 * y[IL2Rbg] * y[IL2_EXT]
+                                        - K_CONVERT * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga]) * y[IL2Rbg]
+                                        + K_REC * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga] + y[IL2Rbga])
+                                        + koff * y[IL2_IL2Rbga]
+                                        - kon_3 * y[IL2Rbga] * y[IL2_EXT]
+                                        + K_CONVERT * (y[IL2_IL2Rbg] + y[IL2_IL2Rbga]) * y[IL2Rbg]
+                                        - K_REC * y[IL2Rbga];
+
+                        return dydt;
+                    };
+
+    /**
+     * Gets the internal amounts of requested key.
+     *
+     * @param key the requested substance
+     */
+    public double getInternal(String key) {
+        return amts[names.indexOf(key)];
+    }
+
+    public void setInternal(String key, double val) {
+        amts[names.indexOf(key)] = val;
+    }
+
+    /**
+     * Steps the metabolism process.
+     *
+     * @param random the random number generator
+     * @param sim the simulation instance
+     */
+    abstract void stepProcess(MersenneTwisterFast random, Simulation sim);
+
+    /**
+     * Gets the external amounts of IL-2.
+     *
+     * <p>Multiply by location volume and divide by 1E12 to convert from cm<sup>3</sup> to
+     * um<sup>3</sup> to get in molecules.
+     *
+     * @param sim the simulation instance
+     */
+    private void updateExternal(Simulation sim) {
+        // Convert to molecules.
+        PatchLattice il2 = (PatchLattice) sim.getLattice("IL-2");
+        extIL2 = il2.getAverageValue(loc) * loc.getVolume() / 1E12;
+    }
+
+    // METHOD: stepModule.
+    public void step(MersenneTwisterFast random, Simulation sim) {
+        // Calculate shell volume 2 um outside of cell.
+        double radCell = Math.cbrt((3.0 / 4.0) * (1.0 / Math.PI) * volume);
+        double radShell = radCell + SHELL_THICKNESS;
+        double volShell =
+                volume * (((radShell * radShell * radShell) / (radCell * radCell * radCell)) - 1.0);
+        f = volShell / loc.getVolume();
+        updateExternal(sim);
+
+        // Check active status.
+        active = c.getActivationStatus();
+        if (active) {
+            activeTicker++;
+        } else {
+            activeTicker = 0;
+        }
+
+        // Calculate external IL-2 used in inflammation module.
+        // Local IL-2 total available to cell is fraction of total available
+        // where that fraction is the relative volume fraction the cell occupies
+        // in the location.
+        amts[IL2_EXT] = extIL2 * f; // [molecules]
+
+        // Solve system of equations.
+        amts = Solver.rungeKutta(dydt, 0, amts, 60, STEP_SIZE);
+
+        // Modify internal inflammation response.
+        stepProcess(random, sim);
+
+        // Update bound array.
+        boundArray[IL2Ticker % boundArray.length] = amts[IL2_INT_TOTAL];
+        IL2Ticker++;
+    }
+
+    /**
+     * Creates a {@code PatchProcessInflammation} for given version.
+     *
+     * @param cell the {@link PatchCellCART} the process is associated with
+     * @param version the process version
+     * @return the process instance
+     */
+    public static PatchProcess make(PatchCell cell, String version) {
+        switch (version.toUpperCase()) {
+            case "CD4":
+                return new PatchProcessInflammationCD4((PatchCellCART) cell);
+            case "CD8":
+                return new PatchProcessInflammationCD8((PatchCellCART) cell);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD4.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD4.java
@@ -1,0 +1,127 @@
+package arcade.patch.agent.process;
+
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.process.Process;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+
+/**
+ * Extension of {@link arcade.patch.agent.process} for CD4 CAR T-cells
+ *
+ * <p>{@code InflammationCD4} determines IL-2 amounts produced for stimulatory effector functions as
+ * a antigen-induced activation state.
+ */
+public class PatchProcessInflammationCD4 extends PatchProcessInflammation {
+
+    /** Rate of IL-2 production due to antigen-induced activation */
+    private final double IL2_PROD_RATE_ACTIVE;
+
+    /** Rate of IL-2 production due to IL-2 feedback */
+    private final double IL2_PROD_RATE_IL2;
+
+    /** Delay in IL-2 synthesis after antigen-induced activation */
+    private final int IL2_SYNTHESIS_DELAY;
+
+    /** Total rate of IL-2 production */
+    private double IL2ProdRate;
+
+    /** Total IL-2 produced in step */
+    private double IL2Produced;
+
+    /** Amount of IL-2 bound in past being used for current IL-2 production calculation */
+    private double priorIL2prod;
+
+    /** External IL-2 sent into environment after each step. Used for testing only */
+    private double IL2EnvTesting;
+
+    /**
+     * Creates a CD4 {@link PatchProcessInflammation} module.
+     *
+     * <p>IL-2 production rate parameters set.
+     *
+     * @param c the {@link PatchCellCART} the module is associated with
+     */
+    public PatchProcessInflammationCD4(PatchCellCART c) {
+        super(c);
+
+        // Set parameters.
+        Parameters parameters = cell.getParameters();
+        this.IL2_PROD_RATE_IL2 = parameters.getDouble("inflammation/IL2_PROD_RATE_IL2");
+        this.IL2_PROD_RATE_ACTIVE = parameters.getDouble("inflammation/IL2_PROD_RATE_ACTIVE");
+        this.IL2_SYNTHESIS_DELAY = parameters.getInt("inflammation/IL2_SYNTHESIS_DELAY");
+        IL2ProdRate = 0;
+    }
+
+    @Override
+    public void stepProcess(MersenneTwisterFast random, Simulation sim) {
+
+        // Determine IL-2 production rate as a function of IL-2 bound.
+        int prodIndex = (IL2Ticker % boundArray.length) - IL2_SYNTHESIS_DELAY;
+        if (prodIndex < 0) {
+            prodIndex += boundArray.length;
+        }
+        priorIL2prod = boundArray[prodIndex];
+        IL2ProdRate = IL2_PROD_RATE_IL2 * (priorIL2prod / IL2_RECEPTORS);
+
+        // Add IL-2 production rate dependent on antigen-induced
+        // cell activation if cell is activated.
+        if (active && activeTicker >= IL2_SYNTHESIS_DELAY) {
+            IL2ProdRate += IL2_PROD_RATE_ACTIVE;
+        }
+
+        // Produce IL-2 to environment.
+        IL2Produced = IL2ProdRate; // [molecules], rate is already per minute
+
+        // Update environment.
+        // Take current IL2 external concentration and add the amount produced,
+        // then convert units back to molecules/cm^3.
+        double IL2Env =
+                (((extIL2 - (extIL2 * f - amts[IL2_EXT])) + IL2Produced) * 1E12 / loc.getVolume());
+
+        // update IL2 env variable for testing
+        IL2EnvTesting = IL2Env;
+
+        sim.getLattice("IL-2").setValue(loc, IL2Env);
+    }
+
+    @Override
+    public void update(Process mod) {
+        PatchProcessInflammationCD4 inflammation = (PatchProcessInflammationCD4) mod;
+        double split = (this.cell.getVolume() / this.volume);
+
+        // Update daughter cell inflammation as a fraction of parent.
+        // this.volume = this.cell.getVolume();
+        this.amts[IL2Rbga] = inflammation.amts[IL2Rbga] * split;
+        this.amts[IL2_IL2Rbg] = inflammation.amts[IL2_IL2Rbg] * split;
+        this.amts[IL2_IL2Rbga] = inflammation.amts[IL2_IL2Rbga] * split;
+        this.amts[IL2Rbg] =
+                IL2_RECEPTORS - this.amts[IL2Rbga] - this.amts[IL2_IL2Rbg] - this.amts[IL2_IL2Rbga];
+        this.amts[IL2_INT_TOTAL] = this.amts[IL2_IL2Rbg] + this.amts[IL2_IL2Rbga];
+        this.amts[IL2R_TOTAL] = this.amts[IL2Rbg] + this.amts[IL2Rbga];
+        this.boundArray = (inflammation.boundArray).clone();
+
+        // Update parent cell with remaining fraction.
+        inflammation.amts[IL2Rbga] *= (1 - split);
+        inflammation.amts[IL2_IL2Rbg] *= (1 - split);
+        inflammation.amts[IL2_IL2Rbga] *= (1 - split);
+        inflammation.amts[IL2Rbg] =
+                IL2_RECEPTORS
+                        - inflammation.amts[IL2Rbga]
+                        - inflammation.amts[IL2_IL2Rbg]
+                        - inflammation.amts[IL2_IL2Rbga];
+        inflammation.amts[IL2_INT_TOTAL] =
+                inflammation.amts[IL2_IL2Rbg] + inflammation.amts[IL2_IL2Rbga];
+        inflammation.amts[IL2R_TOTAL] = inflammation.amts[IL2Rbg] + inflammation.amts[IL2Rbga];
+        inflammation.volume *= (1 - split);
+    }
+
+    /**
+     * Returns final value of external IL2 after stepping process. Exists for testing purposes only
+     *
+     * @return final value of external IL2
+     */
+    public double getIL2EnvTesting() {
+        return IL2EnvTesting;
+    }
+}

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -6,6 +6,12 @@ import arcade.core.sim.Simulation;
 import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCellCART;
 
+/**
+ * Extension of {@link PatchProcessInflammation} for CD8 CAR T-cells
+ * <p>
+ * {@code InflammationCD8} determines granzyme amounts produced for cytotoxic effector
+ * functions as a function of IL-2 bound and antigen-induced activation state.
+ */
 public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
     /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2] */
     private static final double GRANZ_PER_IL2 = 0.005;

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -1,0 +1,92 @@
+package arcade.patch.agent.process;
+
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.process.Process;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+
+public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
+    /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2] */
+    private static final double GRANZ_PER_IL2 = 0.005;
+
+    /** Delay in IL-2 synthesis after antigen-induced activation */
+    private final int GRANZ_SYNTHESIS_DELAY;
+
+    /** Amount of IL-2 bound in past being used for current granzyme production calculation */
+    private double priorIL2granz;
+
+    /**
+     * Creates a CD8 {@link PatchProcessInflammation} module.
+     *
+     * <p>Initial amount of internal granzyme is set. Granzyme production parameters set.
+     *
+     * @param c the {@link PatchCellCART} the module is associated with
+     */
+    public PatchProcessInflammationCD8(PatchCellCART c) {
+        super(c);
+
+        // Set parameters.
+        Parameters parameters = cell.getParameters();
+        this.GRANZ_SYNTHESIS_DELAY = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
+        this.priorIL2granz = 0;
+
+        // Initialize internal, external, and uptake concentration arrays.
+        amts[GRANZYME] = 1; // [molecules]
+
+        // Molecule names.
+        names.add(GRANZYME, "granzyme");
+    }
+
+    public void stepProcess(MersenneTwisterFast random, Simulation sim) {
+
+        // Determine amount of granzyme production based on if cell is activated
+        // as a function of IL-2 production.
+        int granzIndex = (IL2Ticker % boundArray.length) - GRANZ_SYNTHESIS_DELAY;
+        if (granzIndex < 0) {
+            granzIndex += boundArray.length;
+        }
+        priorIL2granz = boundArray[granzIndex];
+
+        if (active && activeTicker > GRANZ_SYNTHESIS_DELAY) {
+            amts[GRANZYME] += GRANZ_PER_IL2 * (priorIL2granz / IL2_RECEPTORS);
+        }
+
+        // Update environment.
+        // Convert units back from molecules to molecules/cm^3.
+        double IL2Env = ((extIL2 - (extIL2 * f - amts[IL2_EXT])) * 1E12 / loc.getVolume());
+        sim.getLattice("IL-2").setValue(loc, IL2Env);
+    }
+
+    @Override
+    public void update(Process mod) {
+        PatchProcessInflammationCD8 inflammation = (PatchProcessInflammationCD8) mod;
+        double split = (this.cell.getVolume() / this.volume);
+
+        // Update daughter cell inflammation as a fraction of parent.
+        this.amts[IL2Rbga] = inflammation.amts[IL2Rbga] * split;
+        this.amts[IL2_IL2Rbg] = inflammation.amts[IL2_IL2Rbg] * split;
+        this.amts[IL2_IL2Rbga] = inflammation.amts[IL2_IL2Rbga] * split;
+        this.amts[IL2Rbg] =
+                IL2_RECEPTORS - this.amts[IL2Rbga] - this.amts[IL2_IL2Rbg] - this.amts[IL2_IL2Rbga];
+        this.amts[IL2_INT_TOTAL] = this.amts[IL2_IL2Rbg] + this.amts[IL2_IL2Rbga];
+        this.amts[IL2R_TOTAL] = this.amts[IL2Rbg] + this.amts[IL2Rbga];
+        this.amts[GRANZYME] = inflammation.amts[GRANZYME] * split;
+        this.boundArray = (inflammation.boundArray).clone();
+
+        // Update parent cell with remaining fraction.
+        inflammation.amts[IL2Rbga] *= (1 - split);
+        inflammation.amts[IL2_IL2Rbg] *= (1 - split);
+        inflammation.amts[IL2_IL2Rbga] *= (1 - split);
+        inflammation.amts[IL2Rbg] =
+                IL2_RECEPTORS
+                        - inflammation.amts[IL2Rbga]
+                        - inflammation.amts[IL2_IL2Rbg]
+                        - inflammation.amts[IL2_IL2Rbga];
+        inflammation.amts[IL2_INT_TOTAL] =
+                inflammation.amts[IL2_IL2Rbg] + inflammation.amts[IL2_IL2Rbga];
+        inflammation.amts[IL2R_TOTAL] = inflammation.amts[IL2Rbg] + inflammation.amts[IL2Rbga];
+        inflammation.amts[GRANZYME] *= (1 - split);
+        inflammation.volume *= (1 - split);
+    }
+}

--- a/test/arcade/patch/agent/process/PatchProcessInflammationCD4Test.java
+++ b/test/arcade/patch/agent/process/PatchProcessInflammationCD4Test.java
@@ -1,0 +1,276 @@
+package arcade.patch.agent.process;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.lattice.PatchLattice;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+
+public class PatchProcessInflammationCD4Test {
+
+    private PatchProcessInflammationCD4 inflammation;
+    private PatchCellCART mockCell;
+    private PatchLattice mockLattice;
+    private Parameters mockParameters;
+    private Simulation mockSim;
+    private MersenneTwisterFast mockRandom;
+    private double cellVolume;
+    private PatchLocation mockLocation;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = Mockito.mock(PatchCellCART.class);
+        mockParameters = Mockito.mock(Parameters.class);
+        mockSim = Mockito.mock(Simulation.class);
+        mockRandom = Mockito.mock(MersenneTwisterFast.class);
+        mockLocation = mock(PatchLocation.class);
+        mockLattice = mock(PatchLattice.class);
+
+        Mockito.when(mockCell.getParameters()).thenReturn(mockParameters);
+        cellVolume = randomDoubleBetween(165, 180);
+        when(mockCell.getVolume()).thenReturn(cellVolume);
+        when(mockCell.getLocation()).thenReturn(mockLocation);
+        when(mockLocation.getVolume()).thenReturn(3.0 / 2.0 / Math.sqrt(3.0) * 30 * 30 * 8.7);
+        when(mockParameters.getDouble(anyString())).thenReturn(1.0);
+        when(mockParameters.getInt(anyString())).thenReturn(1);
+
+        when(mockSim.getLattice(anyString())).thenReturn(mockLattice);
+        doNothing().when(mockLattice).setValue(any(PatchLocation.class), anyDouble());
+    }
+
+    @Test
+    public void testConstructor() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+        assertNotNull(inflammation);
+
+        Field il2ProdRate = PatchProcessInflammationCD4.class.getDeclaredField("IL2ProdRate");
+        il2ProdRate.setAccessible(true);
+        assertEquals(0.0, il2ProdRate.get(inflammation));
+
+        Field il2ProdRateIL2 =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_IL2");
+        il2ProdRateIL2.setAccessible(true);
+        assertEquals(1.0, il2ProdRateIL2.get(inflammation));
+
+        Field il2ProdRateActive =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_ACTIVE");
+        il2ProdRateActive.setAccessible(true);
+        assertEquals(1.0, il2ProdRateActive.get(inflammation));
+
+        Field il2SynthesisDelay =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_SYNTHESIS_DELAY");
+        il2SynthesisDelay.setAccessible(true);
+        assertEquals(1, il2SynthesisDelay.get(inflammation));
+    }
+
+    @Test
+    public void testStepProcess() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field il2ProdRateIL2 =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_IL2");
+        il2ProdRateIL2.setAccessible(true);
+        il2ProdRateIL2.set(inflammation, 0.05);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        Field fraction = PatchProcessInflammation.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(inflammation, 1.0);
+
+        inflammation.stepProcess(mockRandom, mockSim);
+
+        // check that patch lattice set value is called
+        verify(mockLattice, times(1)).setValue(any(PatchLocation.class), anyDouble());
+
+        // check that IL2 produced is calculated correctly
+        Field il2Produced = PatchProcessInflammationCD4.class.getDeclaredField("IL2Produced");
+        il2Produced.setAccessible(true);
+        assertEquals(1.1, il2Produced.get(inflammation));
+
+        // check that extIL2 is calculated correctly
+        double expectedIL2 =
+                (1.1 + inflammation.amts[PatchProcessInflammationCD4.IL2_EXT])
+                        * 1E12
+                        / mockLocation.getVolume();
+        assertEquals(expectedIL2, inflammation.getIL2EnvTesting());
+    }
+
+    @Test
+    public void testStepProcessActive() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field il2ProdRateIL2 =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_IL2");
+        il2ProdRateIL2.setAccessible(true);
+        il2ProdRateIL2.set(inflammation, 0.05);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        Field fraction = PatchProcessInflammation.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(inflammation, 1.0);
+
+        Field activeIl2Rate =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_ACTIVE");
+        activeIl2Rate.setAccessible(true);
+        activeIl2Rate.set(inflammation, 2.5);
+
+        inflammation.stepProcess(mockRandom, mockSim);
+
+        Field il2ProdRate = PatchProcessInflammationCD4.class.getDeclaredField("IL2ProdRate");
+        il2ProdRate.setAccessible(true);
+        assertEquals(2.6, il2ProdRate.get(inflammation));
+    }
+
+    @Test
+    public void testStepProcessInactive() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+
+        inflammation.active = false;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field il2ProdRateIL2 =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_IL2");
+        il2ProdRateIL2.setAccessible(true);
+        il2ProdRateIL2.set(inflammation, 0.05);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        Field fraction = PatchProcessInflammation.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(inflammation, 1.0);
+
+        inflammation.stepProcess(mockRandom, mockSim);
+
+        Field il2ProdRate = PatchProcessInflammationCD4.class.getDeclaredField("IL2ProdRate");
+        il2ProdRate.setAccessible(true);
+        assertEquals(0.1, il2ProdRate.get(inflammation));
+    }
+
+    @Test
+    public void testStepProcessActiveTickerLessThanDelay()
+            throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field il2ProdRateIL2 =
+                PatchProcessInflammationCD4.class.getDeclaredField("IL2_PROD_RATE_IL2");
+        il2ProdRateIL2.setAccessible(true);
+        il2ProdRateIL2.set(inflammation, 0.05);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        Field fraction = PatchProcessInflammation.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(inflammation, 1.0);
+
+        Field delay = PatchProcessInflammationCD4.class.getDeclaredField("IL2_SYNTHESIS_DELAY");
+        delay.setAccessible(true);
+        delay.set(inflammation, 15);
+
+        inflammation.stepProcess(mockRandom, mockSim);
+
+        Field il2ProdRate = PatchProcessInflammationCD4.class.getDeclaredField("IL2ProdRate");
+        il2ProdRate.setAccessible(true);
+        assertEquals(0.1, il2ProdRate.get(inflammation));
+    }
+
+    @Test
+    public void testStepProcessWithZeroIL2ProdRate()
+            throws NoSuchFieldException, IllegalAccessException {
+        when(mockParameters.getDouble("inflammation/IL2_PROD_RATE_IL2")).thenReturn(0.0);
+        when(mockParameters.getDouble("inflammation/IL2_PROD_RATE_ACTIVE")).thenReturn(0.0);
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        Field fraction = PatchProcessInflammation.class.getDeclaredField("f");
+        fraction.setAccessible(true);
+        fraction.set(inflammation, 1.0);
+
+        inflammation.stepProcess(mockRandom, mockSim);
+
+        Field il2ProdRate = PatchProcessInflammationCD4.class.getDeclaredField("IL2ProdRate");
+        il2ProdRate.setAccessible(true);
+        assertEquals(0.0, il2ProdRate.get(inflammation));
+
+        Field il2Produced = PatchProcessInflammationCD4.class.getDeclaredField("IL2Produced");
+        il2Produced.setAccessible(true);
+        assertEquals(0.0, il2Produced.get(inflammation));
+    }
+
+    @Test
+    public void testUpdate() {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+        PatchProcessInflammationCD4 parentProcess = new PatchProcessInflammationCD4(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD4.IL2Rbga] = 100;
+        when(mockCell.getVolume()).thenReturn(cellVolume / 2);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(50, inflammation.amts[PatchProcessInflammationCD4.IL2Rbga]);
+        assertEquals(50, parentProcess.amts[PatchProcessInflammationCD4.IL2Rbga]);
+    }
+
+    @Test
+    public void testUpdateWithZeroVolume() {
+        inflammation = new PatchProcessInflammationCD4(mockCell);
+        PatchProcessInflammationCD4 parentProcess = new PatchProcessInflammationCD4(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD4.IL2Rbga] = 100;
+        when(mockCell.getVolume()).thenReturn(0.0);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(0.0, inflammation.amts[PatchProcessInflammationCD8.IL2Rbga]);
+        assertEquals(0.0, inflammation.amts[PatchProcessInflammationCD8.IL2_IL2Rbg]);
+        assertEquals(0.0, inflammation.amts[PatchProcessInflammationCD8.IL2_IL2Rbga]);
+
+        assertEquals(100, parentProcess.amts[PatchProcessInflammationCD4.IL2Rbga]);
+    }
+}

--- a/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
+++ b/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
@@ -1,0 +1,147 @@
+package arcade.patch.agent.process;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.lattice.PatchLattice;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+
+public class PatchProcessInflammationCD8Test {
+
+    private PatchProcessInflammationCD8 inflammation;
+    private PatchCellCART mockCell;
+    private Parameters mockParameters;
+    private Simulation mockSimulation;
+    private MersenneTwisterFast mockRandom;
+    private double cellVolume;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = Mockito.mock(PatchCellCART.class);
+        mockParameters = Mockito.mock(Parameters.class);
+        mockSimulation = Mockito.mock(Simulation.class);
+        mockRandom = Mockito.mock(MersenneTwisterFast.class);
+        PatchLocation mockLocation = mock(PatchLocation.class);
+        PatchLattice mockLattice = mock(PatchLattice.class);
+
+        Mockito.when(mockCell.getParameters()).thenReturn(mockParameters);
+        cellVolume = randomDoubleBetween(165, 180);
+        when(mockCell.getVolume()).thenReturn(cellVolume);
+        when(mockCell.getLocation()).thenReturn(mockLocation);
+        when(mockLocation.getVolume()).thenReturn(3.0 / 2.0 / Math.sqrt(3.0) * 30 * 30 * 8.7);
+        when(mockParameters.getDouble(anyString())).thenReturn(1.0);
+        when(mockParameters.getInt(anyString())).thenReturn(1);
+
+        when(mockSimulation.getLattice(anyString())).thenReturn(mockLattice);
+        doNothing().when(mockLattice).setValue(any(PatchLocation.class), anyDouble());
+    }
+
+    @Test
+    public void testConstructor() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        assertNotNull(inflammation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+
+        Field prior = PatchProcessInflammationCD8.class.getDeclaredField("priorIL2granz");
+        prior.setAccessible(true);
+        assertEquals(0.0, prior.get(inflammation));
+
+        Field delay = PatchProcessInflammationCD8.class.getDeclaredField("GRANZ_SYNTHESIS_DELAY");
+        delay.setAccessible(true);
+        assertEquals(1, delay.get(inflammation));
+    }
+
+    @Test
+    public void testStepProcess() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertTrue(inflammation.amts[PatchProcessInflammationCD8.GRANZYME] > 1);
+    }
+
+    @Test
+    public void testStepProcessInactive() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = false;
+        inflammation.activeTicker = 10;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void testStepProcessActiveTickerLessThanDelay()
+            throws NoSuchFieldException, IllegalAccessException {
+        Mockito.when(mockParameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY")).thenReturn(5);
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = true;
+        inflammation.activeTicker = 3;
+        inflammation.IL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("IL2_RECEPTORS");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void testUpdate() {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        PatchProcessInflammationCD8 parentProcess = new PatchProcessInflammationCD8(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD8.GRANZYME] = 100;
+        when(mockCell.getVolume()).thenReturn(cellVolume / 2);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(50, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+        assertEquals(50, parentProcess.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void testUpdateZeroVolumeParent() {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        PatchProcessInflammationCD8 parentProcess = new PatchProcessInflammationCD8(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD8.GRANZYME] = 100;
+        when(mockCell.getVolume()).thenReturn(0.0);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(0, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+        assertEquals(100, parentProcess.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+}

--- a/test/arcade/patch/agent/process/PatchProcessInflammationTest.java
+++ b/test/arcade/patch/agent/process/PatchProcessInflammationTest.java
@@ -1,0 +1,69 @@
+package arcade.patch.agent.process;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.lattice.PatchLattice;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class PatchProcessInflammationTest {
+
+    private PatchProcessInflammation inflammation;
+    private PatchCellCART mockCell;
+    private Parameters mockParameters;
+    private Simulation mockSimulation;
+    private MersenneTwisterFast mockRandom;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = Mockito.mock(PatchCellCART.class);
+        mockParameters = Mockito.mock(Parameters.class);
+        mockSimulation = Mockito.mock(Simulation.class);
+        mockRandom = Mockito.mock(MersenneTwisterFast.class);
+        PatchLocation mockLocation = mock(PatchLocation.class);
+        PatchLattice mockLattice = mock(PatchLattice.class);
+
+        Mockito.when(mockCell.getParameters()).thenReturn(mockParameters);
+        Mockito.when(mockCell.getLocation()).thenReturn(mockLocation);
+        Mockito.when(mockCell.getVolume()).thenReturn(150.0);
+        Mockito.when(mockLocation.getVolume()).thenReturn(1000.0);
+        Mockito.when(mockParameters.getDouble(anyString())).thenReturn(1.0);
+        Mockito.when(mockParameters.getInt(anyString())).thenReturn(1);
+        Mockito.when(mockSimulation.getLattice(anyString())).thenReturn(mockLattice);
+        doNothing().when(mockLattice).setValue(any(PatchLocation.class), anyDouble());
+
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(inflammation);
+        assertEquals(0, inflammation.getInternal("IL-2"));
+        assertEquals(1.0, inflammation.getInternal("IL2R_total"));
+    }
+
+    @Test
+    public void testStep() {
+        inflammation.step(mockRandom, mockSimulation);
+        assertTrue(inflammation.getInternal("IL-2") >= 0);
+    }
+
+    @Test
+    public void testGetInternal() {
+        assertEquals(0, inflammation.getInternal("IL-2"));
+    }
+
+    @Test
+    public void testSetInternal() {
+        inflammation.setInternal("IL-2", 10.0);
+        assertEquals(10.0, inflammation.getInternal("IL-2"));
+    }
+}


### PR DESCRIPTION
Partly resolves #40 

_Estimated size: Large_

Change Descriptions:
All inflammation modules are implemented as they were in the original CARCADE model. Certain functions are swapped out for the V3 equivalent. 

`PatchProcessInflammation` class:
- Implementation of inflammation ODEs in which IL-2 is taken up by T cells, and T cell can undertake cytotoxic or stimulatory functions 

`PatchProcessInflammationCD4` class:
- CD4 version of inflammation that determines IL-2 produced for stimulatory functions 

`PatchProcessInflammationCD8` class:
- CD8 version of inflammation that determines granzyme amount produced by the cytotoxic state, as determined by IL-2 bound and activation status

`PatchProcessInflammationTest`, `PatchProcessInflammationCD4Test`, `PatchProcessInflammationTestCD8`  classes:
- added unit tests for each class to verify functionality 
------------------------------
## Reference to other PRs

In an effort to not make this more of an ungodly PR than it already is, I broke the changes up into chunks. I've linked the other PRs below for ease of referencing other classes:

### Parameters (#146)
- parameter.patch.xml
### CART Agents and associated classes (#145)
- PatchCellCART, PatchCellCARTCD4, PatchCellCARTCD8 
- PatchCellContainer
- PatchGrid
- PatchModuleProliferation
- PatchEnums
### Reset Action (#144)
- PatchActionReset
### Kill Action (#143)
- PatchActionKill
### Inflammation Modules (#142)
- PatchProcessInflammation
- PatchProcessInflammationCD4
- PatchProcessInflammationCD8
### Metabolism Modules (#141)
- PatchProcessMetabolism
- PatchProcessMetabolismCART
### Treat Action (#140)
- PatchActionTreat
- PatchSimulationHex
- PatchSimulationRect
### Patch Cell Classes (#139)
- PatchCell
- PatchCellTissue
- PatchCellCancer
