### PR TITLE
[CARCADE Refactor into V3] Add Kill Action 

### DIFF
--- a/src/arcade/patch/agent/action/PatchActionKill.java
+++ b/src/arcade/patch/agent/action/PatchActionKill.java
@@ -1,0 +1,100 @@
+package arcade.patch.agent.action;
+
+import sim.engine.Schedule;
+import sim.engine.SimState;
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.action.Action;
+import arcade.core.sim.Series;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.util.PatchEnums.AntigenFlag;
+import arcade.patch.util.PatchEnums.Domain;
+import arcade.patch.util.PatchEnums.Ordering;
+import arcade.patch.util.PatchEnums.State;
+
+/**
+ * Implementation of {@link Action} for killing tissue agents.
+ *
+ * <p>{@code PatchActionKill} is stepped once after a CD8 CAR T-cell binds to a target tissue cell.
+ * The {@code PatchActionKill} determines if cell has enough granzyme to kill. If so, it kills cell
+ * and calls the reset to neutral helper to return to neutral state. If not, it waits until it has
+ * enough granzyme to kill cell.
+ */
+public class PatchActionKill implements Action {
+
+    /** Target cell cytotoxic CAR T-cell is bound to */
+    PatchCellTissue target;
+
+    /** CAR T-cell inflammation module */
+    PatchProcessInflammation inflammation;
+
+    /** Amount of granzyme inside CAR T-cell */
+    double granzyme;
+
+    /** CAR T-cell that the module is linked to */
+    PatchCellCART c;
+
+    /** Time delay before calling the action [min]. */
+    private final int timeDelay;
+
+    /**
+     * Creates a {@code PatchActionKill} for the given {@link PatchCellCART}.
+     *
+     * @param c the {@link PatchCellCART} the helper is associated with
+     * @param target the {@link PatchCellTissue} the CAR T-cell is bound to
+     */
+    public PatchActionKill(
+            PatchCellCART c,
+            PatchCellTissue target,
+            MersenneTwisterFast random,
+            Series series,
+            Parameters parameters) {
+        this.c = c;
+        this.target = target;
+        this.inflammation = (PatchProcessInflammation) c.getProcess(Domain.INFLAMMATION);
+        this.granzyme = inflammation.getInternal("granzyme");
+        timeDelay = 0;
+    }
+
+    @Override
+    public void schedule(Schedule schedule) {
+        schedule.scheduleOnce(schedule.getTime() + timeDelay, Ordering.ACTIONS.ordinal(), this);
+    }
+
+    @Override
+    public void register(Simulation sim, String population) {}
+
+    @Override
+    public void step(SimState state) {
+        Simulation sim = (Simulation) state;
+
+        // If current CAR T-cell is stopped, stop helper.
+        if (c.isStopped()) {
+            return;
+        }
+
+        // If bound target cell is stopped, stop helper.
+        if (target.isStopped()) {
+            if (c.binding == AntigenFlag.BOUND_ANTIGEN) {
+                c.binding = AntigenFlag.UNBOUND;
+            } else {
+                c.binding = AntigenFlag.BOUND_CELL_RECEPTOR;
+            }
+            return;
+        }
+
+        if (granzyme >= 1) {
+
+            // Kill bound target cell.
+            PatchCellTissue tissueCell = (PatchCellTissue) target;
+            tissueCell.setState(State.APOPTOTIC);
+
+            // Use up some granzyme in the process.
+            granzyme--;
+            inflammation.setInternal("granzyme", granzyme);
+        }
+    }
+}

--- a/test/arcade/patch/agent/action/PatchActionKillTest.java
+++ b/test/arcade/patch/agent/action/PatchActionKillTest.java
@@ -1,0 +1,78 @@
+package arcade.patch.agent.action;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sim.engine.Schedule;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Series;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.agent.module.PatchModuleApoptosis;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums;
+import arcade.patch.util.PatchEnums.AntigenFlag;
+import arcade.patch.util.PatchEnums.State;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class PatchActionKillTest {
+
+    private PatchCellCART mockCell;
+    private PatchCellTissue mockTarget;
+    private PatchProcessInflammation mockInflammation;
+    private PatchActionKill action;
+    private Schedule schedule;
+    private PatchSimulation sim;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = mock(PatchCellCART.class);
+        mockTarget = mock(PatchCellTissue.class);
+        mockInflammation = mock(PatchProcessInflammation.class);
+        MersenneTwisterFast random = new MersenneTwisterFast();
+        Series series = mock(Series.class);
+        Parameters parameters = mock(Parameters.class);
+        schedule = mock(Schedule.class);
+        sim = mock(PatchSimulation.class);
+
+        when(mockCell.getProcess(any())).thenReturn(mockInflammation);
+        when(mockInflammation.getInternal("granzyme")).thenReturn(1.0);
+
+        action = new PatchActionKill(mockCell, mockTarget, random, series, parameters);
+    }
+
+    @Test
+    public void testSchedule() {
+        action.schedule(schedule);
+        verify(schedule)
+                .scheduleOnce(anyDouble(), eq(PatchEnums.Ordering.ACTIONS.ordinal()), eq(action));
+    }
+
+    @Test
+    public void testStep_CARCellStopped() {
+        when(mockCell.isStopped()).thenReturn(true);
+        action.step(sim);
+        verify(mockTarget, never()).setState(any());
+    }
+
+    @Test
+    public void testStep_TargetCellStopped() {
+        when(mockTarget.isStopped()).thenReturn(true);
+        action.step(sim);
+        verify(mockTarget, never()).setState(any());
+        assertEquals(AntigenFlag.BOUND_CELL_RECEPTOR, mockCell.binding);
+    }
+
+    @Test
+    public void testStep_KillTargetCell() {
+        when(mockCell.isStopped()).thenReturn(false);
+        when(mockTarget.isStopped()).thenReturn(false);
+        PatchModuleApoptosis mockProcess = mock(PatchModuleApoptosis.class);
+        when(mockTarget.getModule()).thenReturn(mockProcess);
+        action.step(sim);
+        verify(mockTarget).setState(State.APOPTOTIC);
+        verify(mockInflammation).setInternal("granzyme", 0.0);
+    }
+}


### PR DESCRIPTION
Partly resolves #40 

_Estimated size: Medium_

Change Descriptions:

`PatchActionKill` class:
- Implemented as original CARCADE model action
- Action that is called when CD8 CART cells are cytotoxic, and binds to and kills a target cell.
- If the cd8 cell has enough granzyme, the target cell is set to an apoptotic state, and the granzyme is depleted 

`PatchActionKillTest` class:
- Added unit tests to verify functionality of the class 

------------------------------
## Reference to other PRs

In an effort to not make this more of an ungodly PR than it already is, I broke the changes up into chunks. I've linked the other PRs below for ease of referencing other classes:

### Parameters (#146)
- parameter.patch.xml
### CART Agents and associated classes (#145)
- PatchCellCART, PatchCellCARTCD4, PatchCellCARTCD8 
- PatchCellContainer
- PatchGrid
- PatchModuleProliferation
- PatchEnums
### Reset Action (#144)
- PatchActionReset
### Kill Action (#143)
- PatchActionKill
### Inflammation Modules (#142)
- PatchProcessInflammation
- PatchProcessInflammationCD4
- PatchProcessInflammationCD8
### Metabolism Modules (#141)
- PatchProcessMetabolism
- PatchProcessMetabolismCART
### Treat Action (#140)
- PatchActionTreat
- PatchSimulationHex
- PatchSimulationRect
### Patch Cell Classes (#139)
- PatchCell
- PatchCellTissue
- PatchCellCancer

