### PR TITLE
[CARCADE Refactor into V3] Add Reset Action

### DIFF
--- a/src/arcade/patch/agent/action/PatchActionReset.java
+++ b/src/arcade/patch/agent/action/PatchActionReset.java
@@ -1,0 +1,68 @@
+
+package arcade.patch.agent.action;
+
+import sim.engine.Schedule;
+import sim.engine.SimState;
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.action.Action;
+import arcade.core.sim.Series;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.util.PatchEnums.AntigenFlag;
+import arcade.patch.util.PatchEnums.Ordering;
+import arcade.patch.util.PatchEnums.State;
+
+/**
+ * Implementation of {@link Action} for resetting T cell agents.
+ *
+ * <p>{@code PatchActionReset} is stepped once after a CD8 CAR T-cell binds to a target tissue cell,
+ * or after a CD4 CAR T-cell gets stimulated. The {@code PatchReset} unbinds to any target cell that
+ * the T cell is bound to, and sets the cell state back to quiescent.
+ */
+public class PatchActionReset implements Action {
+
+    /** CAR T-cell inflammation module */
+    PatchProcessInflammation inflammation;
+
+    /** CAR T-cell that the module is linked to */
+    PatchCellCART c;
+
+    /** Time delay before calling the action [min]. */
+    private final int timeDelay;
+
+    /**
+     * Creates a {@code PatchActionReset} for the given {@link PatchCellCART}.
+     *
+     * @param c the {@link PatchCellCART} the helper is associated with
+     */
+    public PatchActionReset(
+            PatchCellCART c, MersenneTwisterFast random, Series series, Parameters parameters) {
+        this.c = c;
+        double boundTime = parameters.getInt("BOUND_TIME");
+        double boundRange = parameters.getInt("BOUND_RANGE");
+        timeDelay = (int) (boundTime + Math.round((boundRange * (2 * random.nextInt() - 1))));
+    }
+
+    @Override
+    public void schedule(Schedule schedule) {
+        schedule.scheduleOnce(schedule.getTime() + timeDelay, Ordering.ACTIONS.ordinal(), this);
+    }
+
+    @Override
+    public void register(Simulation sim, String population) {}
+
+    @Override
+    public void step(SimState state) {
+        // If current CAR T-cell is stopped, stop helper.
+        if (c.isStopped()) {
+            return;
+        }
+
+        if (c.getState() == State.CYTOTOXIC || c.getState() == State.STIMULATORY) {
+            c.binding = AntigenFlag.UNBOUND;
+            c.setState(State.QUIESCENT);
+        }
+    }
+}

--- a/test/arcade/patch/agent/action/PatchActionResetTest.java
+++ b/test/arcade/patch/agent/action/PatchActionResetTest.java
@@ -1,0 +1,110 @@
+
+package arcade.patch.agent.action;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sim.engine.Schedule;
+import sim.engine.SimState;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Series;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.cell.PatchCellCARTCD4;
+import arcade.patch.agent.cell.PatchCellContainer;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.util.PatchEnums;
+import arcade.patch.util.PatchEnums.AntigenFlag;
+import arcade.patch.util.PatchEnums.State;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+import static arcade.core.ARCADETestUtilities.randomIntBetween;
+
+public class PatchActionResetTest {
+
+    private PatchCellCART mockCell;
+    private PatchActionReset actionReset;
+
+    @BeforeEach
+    public void setUp() {
+        MersenneTwisterFast mockRandom = mock(MersenneTwisterFast.class);
+        Series mockSeries = mock(Series.class);
+        Parameters mockParameters = mock(Parameters.class);
+        PatchLocation mockLocation = mock(PatchLocation.class);
+
+        when(mockParameters.getInt("BOUND_TIME")).thenReturn(10);
+        when(mockParameters.getInt("BOUND_RANGE")).thenReturn(5);
+        when(mockRandom.nextInt()).thenReturn(1);
+
+        int id = 1;
+        int parentId = 1;
+        int pop = 4;
+        int age = randomIntBetween(1, 100800);
+        int divisions = 10;
+        double volume = randomDoubleBetween(100, 200);
+        double height = randomDoubleBetween(4, 10);
+        double criticalVolume = randomDoubleBetween(100, 200);
+        double criticalHeight = randomDoubleBetween(4, 10);
+        State state = State.UNDEFINED;
+        ;
+
+        PatchCellContainer container =
+                new PatchCellContainer(
+                        id,
+                        parentId,
+                        pop,
+                        age,
+                        divisions,
+                        state,
+                        volume,
+                        height,
+                        criticalVolume,
+                        criticalHeight);
+
+        mockCell = spy(new PatchCellCARTCD4(container, mockLocation, mockParameters));
+
+        actionReset = new PatchActionReset(mockCell, mockRandom, mockSeries, mockParameters);
+    }
+
+    @Test
+    public void testSchedule() {
+        Schedule mockSchedule = mock(Schedule.class);
+        actionReset.schedule(mockSchedule);
+        verify(mockSchedule)
+                .scheduleOnce(
+                        anyDouble(), eq(PatchEnums.Ordering.ACTIONS.ordinal()), eq(actionReset));
+    }
+
+    @Test
+    public void testStep_CytotoxicState() {
+        when(mockCell.isStopped()).thenReturn(false);
+        mockCell.binding = AntigenFlag.BOUND_ANTIGEN;
+        when(mockCell.getState()).thenReturn(State.CYTOTOXIC);
+
+        actionReset.step(mock(SimState.class));
+
+        verify(mockCell).setState(State.QUIESCENT);
+        assertEquals(AntigenFlag.UNBOUND, mockCell.getAntigenFlag());
+    }
+
+    @Test
+    public void testStep_StimulatoryState() {
+        when(mockCell.isStopped()).thenReturn(false);
+        mockCell.binding = AntigenFlag.BOUND_ANTIGEN;
+        when(mockCell.getState()).thenReturn(State.STIMULATORY);
+
+        actionReset.step(mock(SimState.class));
+
+        verify(mockCell).setState(State.QUIESCENT);
+        assertEquals(AntigenFlag.UNBOUND, mockCell.getAntigenFlag());
+    }
+
+    @Test
+    public void testStep_StoppedCell() {
+        when(mockCell.isStopped()).thenReturn(true);
+        mockCell.binding = AntigenFlag.BOUND_ANTIGEN;
+        actionReset.step(mock(SimState.class));
+        verify(mockCell, never()).setState(any(State.class));
+        assertEquals(AntigenFlag.BOUND_ANTIGEN, mockCell.getAntigenFlag());
+    }
+}


### PR DESCRIPTION
Partly resolves #40 

_Estimated size: Medium_

Change Descriptions:

`PatchActionReset` class:
- As implemented in original CARCADE model. The purpose of this action is to reset T cells after they are stimulated or cytotoxic. The action returns the cell state to quiescent, and for cytotoxic T cells, unbinds the T cell from the target cell.

`PatchActionReset` class:
-  Add unit tests to verify basic functionality of the action.

------------------------------
## Reference to other PRs

In an effort to not make this more of an ungodly PR than it already is, I broke the changes up into chunks. I've linked the other PRs below for ease of referencing other classes:

### Parameters (#146)
- parameter.patch.xml
### CART Agents and associated classes (#145)
- PatchCellCART, PatchCellCARTCD4, PatchCellCARTCD8 
- PatchCellContainer
- PatchGrid
- PatchModuleProliferation
- PatchEnums
### Reset Action (#144)
- PatchActionReset
### Kill Action (#143)
- PatchActionKill
### Inflammation Modules (#142)
- PatchProcessInflammation
- PatchProcessInflammationCD4
- PatchProcessInflammationCD8
### Metabolism Modules (#141)
- PatchProcessMetabolism
- PatchProcessMetabolismCART
### Treat Action (#140)
- PatchActionTreat
- PatchSimulationHex
- PatchSimulationRect
### Patch Cell Classes (#139)
- PatchCell
- PatchCellTissue
- PatchCellCancer