### PR TITLE
Hotfix: fix detaching of location from cell during proliferation

### DIFF
--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -471,7 +471,7 @@ public abstract class PatchCell implements Cell {
 
         if (checkLocation(
                 sim, currentLocation, 0, criticalHeight, pop, maxDensity - densityAdjustment)) {
-            freeLocations.add(currentLocation);
+            freeLocations.add(currentLocation.getClone());
         }
 
         for (Location neighborLocation : currentLocation.getNeighbors()) {

--- a/src/arcade/patch/env/location/PatchLocation.java
+++ b/src/arcade/patch/env/location/PatchLocation.java
@@ -75,6 +75,13 @@ public abstract class PatchLocation implements Location {
     public abstract double getArea();
 
     /**
+     * Gets a shallow copy of the location.
+     *
+     * @return a new instance of location
+     */
+    public abstract PatchLocation getClone();
+
+    /**
      * Gets the patch coordinate in the {@link arcade.core.env.grid.Grid}.
      *
      * <p>These are not necessarily the same as the {@link arcade.core.env.lattice.Lattice}

--- a/src/arcade/patch/env/location/PatchLocationHex.java
+++ b/src/arcade/patch/env/location/PatchLocationHex.java
@@ -147,6 +147,11 @@ public final class PatchLocationHex extends PatchLocation {
         return NUM_SUBCOORDINATES;
     }
 
+    @Override
+    public PatchLocationHex getClone() {
+        return new PatchLocationHex((CoordinateUVWZ) this.coordinate);
+    }
+
     /**
      * Updates static configuration variables.
      *

--- a/src/arcade/patch/env/location/PatchLocationRect.java
+++ b/src/arcade/patch/env/location/PatchLocationRect.java
@@ -142,7 +142,7 @@ public final class PatchLocationRect extends PatchLocation {
 
     @Override
     public PatchLocationRect getClone() {
-        return new PatchLocationRect((CoordinateXYZ) getCoordinate());
+        return new PatchLocationRect((CoordinateXYZ) this.coordinate);
     }
 
     /**

--- a/src/arcade/patch/env/location/PatchLocationRect.java
+++ b/src/arcade/patch/env/location/PatchLocationRect.java
@@ -140,6 +140,11 @@ public final class PatchLocationRect extends PatchLocation {
         return NUM_SUBCOORDINATES;
     }
 
+    @Override
+    public PatchLocationRect getClone() {
+        return new PatchLocationRect((CoordinateXYZ) getCoordinate());
+    }
+
     /**
      * Updates static configuration variables.
      *

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -411,6 +411,7 @@ public class PatchCellTest {
 
         doReturn(1000.).when(locationMock).getVolume();
         doReturn(100.).when(locationMock).getArea();
+        doReturn(locationMock).when(locationMock).getClone();
 
         PatchLocation freeLocation = mock(PatchLocation.class);
         doReturn(new Bag()).when(gridMock).getObjectsAtLocation(freeLocation);

--- a/test/arcade/patch/env/location/PatchLocationHexTest.java
+++ b/test/arcade/patch/env/location/PatchLocationHexTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import arcade.core.env.location.Location;
 import static org.junit.jupiter.api.Assertions.*;
+import static arcade.core.ARCADETestUtilities.*;
 
 public class PatchLocationHexTest {
     @Test
@@ -96,5 +97,26 @@ public class PatchLocationHexTest {
         expected.add(new PatchLocationHex(new CoordinateUVWZ(3, -3, -0, 0)));
         assertEquals(expected.size(), actual.size());
         assertTrue(expected.containsAll(actual) && actual.containsAll(expected));
+    }
+
+    @Test
+    public void getClone_called_cloneUpdatesIndependently() {
+        int u1 = randomIntBetween(-10, 10);
+        int v1 = randomIntBetween(-10, 10);
+        int w1 = randomIntBetween(-10, 10);
+        int z1 = randomIntBetween(0, 10);
+        int u2 = randomIntBetween(-10, 10);
+        int v2 = randomIntBetween(-10, 10);
+        int w2 = randomIntBetween(-10, 10);
+        int z2 = randomIntBetween(0, 10);
+
+        PatchLocationHex originalLocation = new PatchLocationHex(u1, v1, w1, z1);
+        PatchLocationHex updateLocation = new PatchLocationHex(u2, v2, w2, z2);
+
+        PatchLocationHex locationClone = originalLocation.getClone();
+        locationClone.update(updateLocation);
+
+        assertEquals(locationClone, updateLocation);
+        assertNotEquals(locationClone, originalLocation);
     }
 }

--- a/test/arcade/patch/env/location/PatchLocationRectTest.java
+++ b/test/arcade/patch/env/location/PatchLocationRectTest.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import arcade.core.env.location.Location;
 import static org.junit.jupiter.api.Assertions.*;
+import static arcade.core.ARCADETestUtilities.randomIntBetween;
 
 public class PatchLocationRectTest {
     @Test
@@ -97,5 +98,24 @@ public class PatchLocationRectTest {
         for (int i = 0; i < expected.size(); i++) {
             assertTrue(actual.contains(expected.get(i)));
         }
+    }
+
+    @Test
+    public void getClone_called_cloneUpdatesIndependently() {
+        int x1 = randomIntBetween(-10, 10);
+        int y1 = randomIntBetween(-10, 10);
+        int z1 = randomIntBetween(0, 10);
+        int x2 = randomIntBetween(-10, 10);
+        int y2 = randomIntBetween(-10, 10);
+        int z2 = randomIntBetween(0, 10);
+
+        PatchLocationRect originalLocation = new PatchLocationRect(x1, y1, z1);
+        PatchLocationRect updateLocation = new PatchLocationRect(x2, y2, z2);
+
+        PatchLocationRect locationClone = originalLocation.getClone();
+        locationClone.update(updateLocation);
+
+        assertEquals(locationClone, updateLocation);
+        assertNotEquals(locationClone, originalLocation);
     }
 }


### PR DESCRIPTION
Updated `findFreeLocations` method would return the original current location object rather than a clone of the object, therefore when a new cell was created in the same location, the daughter cells had the same current location object reference.  Resolves #135.

size: small 

Summary of changes: 

- Added a `getClone()` to `PatchLocation` subclasses to create a new instance with the same coordinates. 
- `findFreeLocations` method returns clone of current location rather than the actual current location object.