### PR TITLE
CARCADE Refactor 2a: CD8 Cell Agent and Associated Inflammation Process

### DIFF
--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -351,10 +351,6 @@ public abstract class PatchCell implements Cell {
                 module = new PatchModuleNecrosis(this);
                 break;
             case QUIESCENT:
-                if (this instanceof PatchCellCART) {
-                    throw new UnsupportedOperationException(
-                            "CART cells do not have corresponding state");
-                }
                 module = new PatchModuleQuiescence(this);
                 break;
             case SENESCENT:

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -352,7 +352,8 @@ public abstract class PatchCell implements Cell {
                 break;
             case QUIESCENT:
                 if (this instanceof PatchCellCART) {
-                    this.setState(State.UNDEFINED);
+                    throw new UnsupportedOperationException(
+                            "CART cells do not have corresponding state");
                 } else {
                     module = new PatchModuleQuiescence(this);
                 }

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -354,9 +354,8 @@ public abstract class PatchCell implements Cell {
                 if (this instanceof PatchCellCART) {
                     throw new UnsupportedOperationException(
                             "CART cells do not have corresponding state");
-                } else {
-                    module = new PatchModuleQuiescence(this);
                 }
+                module = new PatchModuleQuiescence(this);
                 break;
             case SENESCENT:
                 module = new PatchModuleSenescence(this);

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -351,7 +351,11 @@ public abstract class PatchCell implements Cell {
                 module = new PatchModuleNecrosis(this);
                 break;
             case QUIESCENT:
-                module = new PatchModuleQuiescence(this);
+                if (this instanceof PatchCellCART) {
+                    this.setState(State.UNDEFINED);
+                } else {
+                    module = new PatchModuleQuiescence(this);
+                }
                 break;
             case SENESCENT:
                 module = new PatchModuleSenescence(this);
@@ -361,11 +365,6 @@ public abstract class PatchCell implements Cell {
                 break;
             case STIMULATORY:
                 throw new UnsupportedOperationException();
-            case QUIESCENT:
-                if (this instanceof PatchCellCART) {
-                    this.setState(State.UNDEFINED);
-                }
-                break;
             default:
                 module = null;
                 break;

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -18,6 +18,7 @@ import arcade.core.util.GrabBag;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Parameters;
 import arcade.patch.agent.module.PatchModuleApoptosis;
+import arcade.patch.agent.module.PatchModuleCytotoxicity;
 import arcade.patch.agent.module.PatchModuleMigration;
 import arcade.patch.agent.module.PatchModuleProliferation;
 import arcade.patch.agent.process.PatchProcessInflammation;
@@ -345,9 +346,15 @@ public abstract class PatchCell implements Cell {
                 module = new PatchModuleApoptosis(this);
                 break;
             case CYTOTOXIC:
-                throw new UnsupportedOperationException();
+                module = new PatchModuleCytotoxicity(this);
+                break;
             case STIMULATORY:
                 throw new UnsupportedOperationException();
+            case QUIESCENT:
+                if (this instanceof PatchCellCART) {
+                    this.setState(State.UNDEFINED);
+                }
+                break;
             default:
                 module = null;
                 break;

--- a/src/arcade/patch/agent/cell/PatchCellCART.java
+++ b/src/arcade/patch/agent/cell/PatchCellCART.java
@@ -108,6 +108,9 @@ public abstract class PatchCellCART extends PatchCell {
     /** Fraction of proliferative cells that become apoptotic. */
     protected final double proliferativeFraction;
 
+    /** Target cell that current T cell is bound to. */
+    protected PatchCell boundTarget;
+
     /**
      * Creates a {@code PatchCellCART} agent. *
      *
@@ -155,6 +158,7 @@ public abstract class PatchCellCART extends PatchCell {
         boundSelfAntigensCount = 0;
         lastActiveTicker = 0;
         activated = true;
+        boundTarget = null;
 
         // Set loaded parameters.
         exhaustedFraction = parameters.getDouble("EXHAUSTED_FRAC");
@@ -394,5 +398,20 @@ public abstract class PatchCellCART extends PatchCell {
     /** Randomly increases number of self receptors after CAR binding. */
     private void updateSelfReceptors() {
         selfReceptors += (int) ((double) selfReceptorsStart * (0.95 + Math.random() / 10));
+    }
+
+    /**
+     * Returns bound cell.
+     *
+     * @return the bound cell
+     */
+    public PatchCell getBoundTarget() {
+        return this.boundTarget;
+    }
+
+    /** Sets binding flag to unbound and binding target to null. */
+    public void unbind() {
+        super.setBindingFlag(AntigenFlag.UNBOUND);
+        this.boundTarget = null;
     }
 }

--- a/src/arcade/patch/agent/cell/PatchCellCART.java
+++ b/src/arcade/patch/agent/cell/PatchCellCART.java
@@ -48,6 +48,10 @@ import static arcade.patch.util.PatchEnums.State;
  * parameter classes have support for loading in distributions to reflect heterogeneity.
  */
 public abstract class PatchCellCART extends PatchCell {
+
+    /** Constant for amount of minutes in a day. */
+    protected final int DAYS_IN_MINUTES = 1440;
+
     /** Cell activation flag. */
     protected boolean activated;
 

--- a/src/arcade/patch/agent/cell/PatchCellCART.java
+++ b/src/arcade/patch/agent/cell/PatchCellCART.java
@@ -50,7 +50,7 @@ import static arcade.patch.util.PatchEnums.State;
 public abstract class PatchCellCART extends PatchCell {
 
     /** Constant for amount of minutes in a day. */
-    protected final int DAYS_IN_MINUTES = 1440;
+    public static final int DAYS_IN_MINUTES = 1440;
 
     /** Cell activation flag. */
     protected boolean activated;

--- a/src/arcade/patch/agent/cell/PatchCellCART.java
+++ b/src/arcade/patch/agent/cell/PatchCellCART.java
@@ -50,7 +50,7 @@ import static arcade.patch.util.PatchEnums.State;
 public abstract class PatchCellCART extends PatchCell {
 
     /** Constant for amount of minutes in a day. */
-    public static final int DAYS_IN_MINUTES = 1440;
+    public static final int MINUTES_IN_DAY = 1440;
 
     /** Cell activation flag. */
     protected boolean activated;

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -40,7 +40,7 @@ public class PatchCellCARTCD8 extends PatchCellCART {
 
     @Override
     public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
-        divisions--;
+        divisions++;
         return new PatchCellContainer(
                 newID,
                 id,

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -13,6 +13,7 @@ import arcade.patch.util.PatchEnums.State;
 
 /** Extension of {@link PatchCellCART} for CD8 CART-cells with selected module versions. */
 public class PatchCellCARTCD8 extends PatchCellCART {
+
     /**
      * Creates a T cell {@code PatchCellCARTCD8} agent. *
      *
@@ -67,12 +68,13 @@ public class PatchCellCARTCD8 extends PatchCellCART {
         }
 
         super.lastActiveTicker++;
-        if (super.lastActiveTicker != 0 && super.lastActiveTicker % 1440 == 0) {
+
+        if (super.lastActiveTicker != 0 && super.lastActiveTicker % DAYS_IN_MINUTES == 0) {
             if (super.boundCARAntigensCount != 0) {
                 super.boundCARAntigensCount--;
             }
         }
-        if (super.lastActiveTicker / 1440 > 7) {
+        if (super.lastActiveTicker / DAYS_IN_MINUTES > 7) {
             super.activated = false;
         }
 

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -74,7 +74,7 @@ public class PatchCellCARTCD8 extends PatchCellCART {
                 super.boundCARAntigensCount--;
             }
         }
-        if (super.lastActiveTicker / DAYS_IN_MINUTES > 7) {
+        if (super.lastActiveTicker / DAYS_IN_MINUTES >= 7) {
             super.activated = false;
         }
 

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -11,6 +11,7 @@ import arcade.patch.util.PatchEnums.AntigenFlag;
 import arcade.patch.util.PatchEnums.Domain;
 import arcade.patch.util.PatchEnums.State;
 
+/** Extension of {@link PatchCellCART} for CD8 CART-cells with selected module versions. */
 public class PatchCellCARTCD8 extends PatchCellCART {
     /**
      * Creates a T cell {@code PatchCellCARTCD8} agent. *
@@ -57,7 +58,6 @@ public class PatchCellCARTCD8 extends PatchCellCART {
     public void step(SimState simstate) {
         Simulation sim = (Simulation) simstate;
 
-        // Increase age of cell.
         super.age++;
 
         if (state != State.APOPTOTIC && age > apoptosisAge) {
@@ -66,14 +66,16 @@ public class PatchCellCARTCD8 extends PatchCellCART {
             this.activated = false;
         }
 
-        // Increase time since last active ticker
         super.lastActiveTicker++;
         if (super.lastActiveTicker != 0 && super.lastActiveTicker % 1440 == 0) {
-            if (super.boundCARAntigensCount != 0) super.boundCARAntigensCount--;
+            if (super.boundCARAntigensCount != 0) {
+                super.boundCARAntigensCount--;
+            }
         }
-        if (super.lastActiveTicker / 1440 > 7) super.activated = false;
+        if (super.lastActiveTicker / 1440 > 7) {
+            super.activated = false;
+        }
 
-        // Step metabolism process.
         super.processes.get(Domain.METABOLISM).step(simstate.random, sim);
 
         // Check energy status. If cell has less energy than threshold, it will
@@ -97,10 +99,8 @@ public class PatchCellCARTCD8 extends PatchCellCART {
             }
         }
 
-        // Step inflammation process.
         super.processes.get(Domain.INFLAMMATION).step(simstate.random, sim);
 
-        // Change state from undefined.
         if (super.state == State.UNDEFINED || super.state == State.PAUSED) {
             if (divisions == 0) {
                 if (simstate.random.nextDouble() > super.senescentFraction) {
@@ -111,7 +111,6 @@ public class PatchCellCARTCD8 extends PatchCellCART {
                 super.unbind();
                 this.activated = false;
             } else {
-                // Cell attempts to bind to a target
                 PatchCellTissue target = super.bindTarget(sim, location, simstate.random);
                 super.boundTarget = target;
 
@@ -164,7 +163,6 @@ public class PatchCellCARTCD8 extends PatchCellCART {
             }
         }
 
-        // Step the module for the cell state.
         if (super.module != null) {
             super.module.step(simstate.random, sim);
         }

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -104,7 +104,7 @@ public class PatchCellCARTCD8 extends PatchCellCART {
         super.processes.get(Domain.INFLAMMATION).step(simstate.random, sim);
 
         if (super.state == State.UNDEFINED || super.state == State.PAUSED) {
-            if (divisions == 0) {
+            if (divisions == divisionPotential) {
                 if (simstate.random.nextDouble() > super.senescentFraction) {
                     super.setState(State.APOPTOTIC);
                 } else {

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -1,0 +1,172 @@
+package arcade.patch.agent.cell;
+
+import sim.engine.SimState;
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.cell.CellState;
+import arcade.core.env.location.Location;
+import arcade.core.sim.Simulation;
+import arcade.core.util.GrabBag;
+import arcade.core.util.Parameters;
+import arcade.patch.util.PatchEnums.AntigenFlag;
+import arcade.patch.util.PatchEnums.Domain;
+import arcade.patch.util.PatchEnums.State;
+
+public class PatchCellCARTCD8 extends PatchCellCART {
+    /**
+     * Creates a T cell {@code PatchCellCARTCD8} agent. *
+     *
+     * @param container the cell container
+     * @param location the {@link Location} of the cell
+     * @param parameters the dictionary of parameters
+     */
+    public PatchCellCARTCD8(
+            PatchCellContainer container, Location location, Parameters parameters) {
+        this(container, location, parameters, null);
+    }
+
+    /**
+     * Creates a T cell {@code PatchCellCARTCD8} agent. *
+     *
+     * @param container the cell container
+     * @param location the {@link Location} of the cell
+     * @param parameters the dictionary of parameters
+     * @param links the map of population links
+     */
+    public PatchCellCARTCD8(
+            PatchCellContainer container, Location location, Parameters parameters, GrabBag links) {
+        super(container, location, parameters, links);
+    }
+
+    @Override
+    public PatchCellContainer make(int newID, CellState newState, MersenneTwisterFast random) {
+        divisions--;
+        return new PatchCellContainer(
+                newID,
+                id,
+                pop,
+                age,
+                divisions,
+                newState,
+                volume,
+                height,
+                criticalVolume,
+                criticalHeight);
+    }
+
+    @Override
+    public void step(SimState simstate) {
+        Simulation sim = (Simulation) simstate;
+
+        // Increase age of cell.
+        super.age++;
+
+        if (state != State.APOPTOTIC && age > apoptosisAge) {
+            setState(State.APOPTOTIC);
+            super.unbind();
+            this.activated = false;
+        }
+
+        // Increase time since last active ticker
+        super.lastActiveTicker++;
+        if (super.lastActiveTicker != 0 && super.lastActiveTicker % 1440 == 0) {
+            if (super.boundCARAntigensCount != 0) super.boundCARAntigensCount--;
+        }
+        if (super.lastActiveTicker / 1440 > 7) super.activated = false;
+
+        // Step metabolism process.
+        super.processes.get(Domain.METABOLISM).step(simstate.random, sim);
+
+        // Check energy status. If cell has less energy than threshold, it will
+        // apoptose. If overall energy is negative, then cell enters quiescence.
+        if (state != State.APOPTOTIC) {
+            if (super.energy < super.energyThreshold) {
+
+                super.setState(State.APOPTOTIC);
+                super.unbind();
+                this.activated = false;
+            } else if (state != State.ANERGIC
+                    && state != State.SENESCENT
+                    && state != State.EXHAUSTED
+                    && state != State.STARVED
+                    && energy < 0) {
+
+                super.setState(State.STARVED);
+                super.unbind();
+            } else if (state == State.STARVED && energy >= 0) {
+                super.setState(State.UNDEFINED);
+            }
+        }
+
+        // Step inflammation process.
+        super.processes.get(Domain.INFLAMMATION).step(simstate.random, sim);
+
+        // Change state from undefined.
+        if (super.state == State.UNDEFINED || super.state == State.PAUSED) {
+            if (divisions == 0) {
+                if (simstate.random.nextDouble() > super.senescentFraction) {
+                    super.setState(State.APOPTOTIC);
+                } else {
+                    super.setState(State.SENESCENT);
+                }
+                super.unbind();
+                this.activated = false;
+            } else {
+                // Cell attempts to bind to a target
+                PatchCellTissue target = super.bindTarget(sim, location, simstate.random);
+                super.boundTarget = target;
+
+                // If cell is bound to both antigen and self it will become anergic.
+                if (super.getBindingFlag() == AntigenFlag.BOUND_ANTIGEN_CELL_RECEPTOR) {
+                    if (simstate.random.nextDouble() > super.anergicFraction) {
+                        super.setState(State.APOPTOTIC);
+                    } else {
+                        super.setState(State.ANERGIC);
+                    }
+                    super.unbind();
+                    this.activated = false;
+                } else if (super.getBindingFlag() == AntigenFlag.BOUND_ANTIGEN) {
+                    // If cell is only bound to target antigen, the cell
+                    // can potentially become properly activated.
+
+                    // Check overstimulation. If cell has bound to
+                    // target antigens too many times, becomes exhausted.
+                    if (boundCARAntigensCount > maxAntigenBinding) {
+                        if (simstate.random.nextDouble() > super.exhaustedFraction) {
+                            super.setState(State.APOPTOTIC);
+                        } else {
+                            super.setState(State.EXHAUSTED);
+                        }
+                        super.unbind();
+                        this.activated = false;
+                    } else {
+                        // if CD8 cell is properly activated, it can be cytotoxic
+                        this.lastActiveTicker = 0;
+                        this.activated = true;
+                        super.setState(State.CYTOTOXIC);
+                    }
+                } else {
+                    // If self binding, unbind
+                    if (super.getBindingFlag() == AntigenFlag.BOUND_CELL_RECEPTOR) {
+                        super.unbind();
+                    }
+                    // Check activation status. If cell has been activated before,
+                    // it will proliferate. If not, it will migrate.
+                    if (activated) {
+                        super.setState(State.PROLIFERATIVE);
+                    } else {
+                        if (simstate.random.nextDouble() > super.proliferativeFraction) {
+                            super.setState(State.MIGRATORY);
+                        } else {
+                            super.setState(State.PROLIFERATIVE);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step the module for the cell state.
+        if (super.module != null) {
+            super.module.step(simstate.random, sim);
+        }
+    }
+}

--- a/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
+++ b/src/arcade/patch/agent/cell/PatchCellCARTCD8.java
@@ -69,12 +69,12 @@ public class PatchCellCARTCD8 extends PatchCellCART {
 
         super.lastActiveTicker++;
 
-        if (super.lastActiveTicker != 0 && super.lastActiveTicker % DAYS_IN_MINUTES == 0) {
+        if (super.lastActiveTicker != 0 && super.lastActiveTicker % MINUTES_IN_DAY == 0) {
             if (super.boundCARAntigensCount != 0) {
                 super.boundCARAntigensCount--;
             }
         }
-        if (super.lastActiveTicker / DAYS_IN_MINUTES >= 7) {
+        if (super.lastActiveTicker / MINUTES_IN_DAY >= 7) {
             super.activated = false;
         }
 

--- a/src/arcade/patch/agent/cell/PatchCellContainer.java
+++ b/src/arcade/patch/agent/cell/PatchCellContainer.java
@@ -115,6 +115,8 @@ public final class PatchCellContainer implements CellContainer {
                 return new PatchCellCancer(this, location, parameters, links);
             case "cancer_stem":
                 return new PatchCellCancerStem(this, location, parameters, links);
+            case "cart_cd8":
+                return new PatchCellCARTCD8(this, location, parameters, links);
             case "random":
                 return new PatchCellRandom(this, location, parameters, links);
         }

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -28,17 +28,11 @@ public class PatchModuleCytotoxicity extends PatchModule {
     /** Amount of granzyme inside CAR T-cell. */
     double granzyme;
 
-    /** Time delay before calling the action [min]. */
-    private int timeDelay;
+    /** Average time that T cell is bound to target [min]. */
+    private final int timeDelay;
 
     /** Ticker to keep track of the time delay [min]. */
     private int ticker;
-
-    /** Average time that T cell is bound to target [min]. */
-    private double boundTime;
-
-    /** Range in bound time [min]. */
-    private double boundRange;
 
     /**
      * Creates a {@code PatchActionKill} for the given {@link PatchCellCART}.
@@ -52,9 +46,7 @@ public class PatchModuleCytotoxicity extends PatchModule {
         this.granzyme = inflammation.getInternal("granzyme");
 
         Parameters parameters = cell.getParameters();
-        this.boundTime = parameters.getInt("BOUND_TIME");
-        this.boundRange = parameters.getInt("BOUND_RANGE");
-        this.timeDelay = 0;
+        this.timeDelay = parameters.getInt("BOUND_TIME");
         this.ticker = 0;
     }
 
@@ -71,8 +63,6 @@ public class PatchModuleCytotoxicity extends PatchModule {
         }
 
         if (ticker == 0) {
-            this.timeDelay =
-                    (int) (boundTime + Math.round((boundRange * (2 * random.nextDouble() - 1))));
             if (granzyme >= 1) {
                 PatchCellTissue tissueCell = (PatchCellTissue) target;
                 tissueCell.setState(State.APOPTOTIC);

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -1,0 +1,88 @@
+package arcade.patch.agent.module;
+
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.util.PatchEnums;
+
+/**
+ * Implementation of {@link Module} for killing tissue agents.
+ *
+ * <p>{@code PatchModuleCytotoxicity} is stepped once after a CD8 CAR T-cell binds to a target
+ * tissue cell. The {@code PatchModuleCytotoxicity} determines if cell has enough granzyme to kill.
+ * If so, it kills cell and calls the reset to neutral helper to return to neutral state. If not, it
+ * waits until it has enough granzyme to kill cell.
+ */
+public class PatchModuleCytotoxicity extends PatchModule {
+    /** Target cell cytotoxic CAR T-cell is bound to */
+    PatchCellTissue target;
+
+    /** CAR T-cell inflammation module */
+    PatchProcessInflammation inflammation;
+
+    /** Amount of granzyme inside CAR T-cell */
+    double granzyme;
+
+    /** Time delay before calling the action [min]. */
+    private int timeDelay;
+
+    /** Ticker to keep track of the time delay [min]. */
+    private int ticker;
+
+    /** Average time that T cell is bound to target [min]. */
+    private double boundTime;
+
+    /** Range in bound time [min]. */
+    private double boundRange;
+
+    /**
+     * Creates a {@code PatchActionKill} for the given {@link PatchCellCART}.
+     *
+     * @param c the {@link PatchCell} the helper is associated with
+     */
+    public PatchModuleCytotoxicity(PatchCell c) {
+        super(c);
+        this.target = (PatchCellTissue) ((PatchCellCART) c).getBoundTarget();
+        this.inflammation = (PatchProcessInflammation) c.getProcess(PatchEnums.Domain.INFLAMMATION);
+        this.granzyme = inflammation.getInternal("granzyme");
+
+        Parameters parameters = c.getParameters();
+        this.boundTime = parameters.getInt("BOUND_TIME");
+        this.boundRange = parameters.getInt("BOUND_RANGE");
+        this.timeDelay = 0;
+        this.ticker = 0;
+    }
+
+    @Override
+    public void step(MersenneTwisterFast random, Simulation sim) {
+        if (cell.isStopped()) {
+            return;
+        }
+
+        if (target.isStopped()) {
+            ((PatchCellCART) cell).unbind();
+            cell.setState(PatchEnums.State.UNDEFINED);
+            return;
+        }
+
+        if (ticker == 0) {
+            this.timeDelay =
+                    (int) (boundTime + Math.round((boundRange * (2 * random.nextInt() - 1))));
+            if (granzyme >= 1) {
+                PatchCellTissue tissueCell = (PatchCellTissue) target;
+                tissueCell.setState(PatchEnums.State.APOPTOTIC);
+                granzyme--;
+                inflammation.setInternal("granzyme", granzyme);
+            }
+        } else if (ticker >= timeDelay) {
+            ((PatchCellCART) cell).unbind();
+            cell.setState(PatchEnums.State.UNDEFINED);
+        }
+
+        ticker++;
+    }
+}

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -42,15 +42,16 @@ public class PatchModuleCytotoxicity extends PatchModule {
     /**
      * Creates a {@code PatchActionKill} for the given {@link PatchCellCART}.
      *
-     * @param c the {@link PatchCell} the helper is associated with
+     * @param cell the {@link PatchCell} the helper is associated with
      */
-    public PatchModuleCytotoxicity(PatchCell c) {
-        super(c);
-        this.target = (PatchCellTissue) ((PatchCellCART) c).getBoundTarget();
-        this.inflammation = (PatchProcessInflammation) c.getProcess(PatchEnums.Domain.INFLAMMATION);
+    public PatchModuleCytotoxicity(PatchCell cell) {
+        super(cell);
+        this.target = (PatchCellTissue) ((PatchCellCART) cell).getBoundTarget();
+        this.inflammation =
+                (PatchProcessInflammation) cell.getProcess(PatchEnums.Domain.INFLAMMATION);
         this.granzyme = inflammation.getInternal("granzyme");
 
-        Parameters parameters = c.getParameters();
+        Parameters parameters = cell.getParameters();
         this.boundTime = parameters.getInt("BOUND_TIME");
         this.boundRange = parameters.getInt("BOUND_RANGE");
         this.timeDelay = 0;

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -18,13 +18,13 @@ import arcade.patch.util.PatchEnums;
  * waits until it has enough granzyme to kill cell.
  */
 public class PatchModuleCytotoxicity extends PatchModule {
-    /** Target cell cytotoxic CAR T-cell is bound to */
+    /** Target cell cytotoxic CAR T-cell is bound to. */
     PatchCellTissue target;
 
-    /** CAR T-cell inflammation module */
+    /** CAR T-cell inflammation module. */
     PatchProcessInflammation inflammation;
 
-    /** Amount of granzyme inside CAR T-cell */
+    /** Amount of granzyme inside CAR T-cell. */
     double granzyme;
 
     /** Time delay before calling the action [min]. */

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -7,7 +7,8 @@ import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.agent.process.PatchProcessInflammation;
-import arcade.patch.util.PatchEnums;
+import static arcade.patch.util.PatchEnums.Domain;
+import static arcade.patch.util.PatchEnums.State;
 
 /**
  * Implementation of {@link Module} for killing tissue agents.
@@ -47,8 +48,7 @@ public class PatchModuleCytotoxicity extends PatchModule {
     public PatchModuleCytotoxicity(PatchCell cell) {
         super(cell);
         this.target = (PatchCellTissue) ((PatchCellCART) cell).getBoundTarget();
-        this.inflammation =
-                (PatchProcessInflammation) cell.getProcess(PatchEnums.Domain.INFLAMMATION);
+        this.inflammation = (PatchProcessInflammation) cell.getProcess(Domain.INFLAMMATION);
         this.granzyme = inflammation.getInternal("granzyme");
 
         Parameters parameters = cell.getParameters();
@@ -66,7 +66,7 @@ public class PatchModuleCytotoxicity extends PatchModule {
 
         if (target.isStopped()) {
             ((PatchCellCART) cell).unbind();
-            cell.setState(PatchEnums.State.UNDEFINED);
+            cell.setState(State.UNDEFINED);
             return;
         }
 
@@ -75,13 +75,13 @@ public class PatchModuleCytotoxicity extends PatchModule {
                     (int) (boundTime + Math.round((boundRange * (2 * random.nextInt() - 1))));
             if (granzyme >= 1) {
                 PatchCellTissue tissueCell = (PatchCellTissue) target;
-                tissueCell.setState(PatchEnums.State.APOPTOTIC);
+                tissueCell.setState(State.APOPTOTIC);
                 granzyme--;
                 inflammation.setInternal("granzyme", granzyme);
             }
         } else if (ticker >= timeDelay) {
             ((PatchCellCART) cell).unbind();
-            cell.setState(PatchEnums.State.UNDEFINED);
+            cell.setState(State.UNDEFINED);
         }
 
         ticker++;

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -72,7 +72,7 @@ public class PatchModuleCytotoxicity extends PatchModule {
 
         if (ticker == 0) {
             this.timeDelay =
-                    (int) (boundTime + Math.round((boundRange * (2 * random.nextInt() - 1))));
+                    (int) (boundTime + Math.round((boundRange * (2 * random.nextDouble() - 1))));
             if (granzyme >= 1) {
                 PatchCellTissue tissueCell = (PatchCellTissue) target;
                 tissueCell.setState(State.APOPTOTIC);

--- a/src/arcade/patch/agent/module/PatchModuleProliferation.java
+++ b/src/arcade/patch/agent/module/PatchModuleProliferation.java
@@ -8,6 +8,7 @@ import arcade.core.sim.Simulation;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.process.PatchProcess;
 import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.location.PatchLocation;
@@ -73,12 +74,20 @@ public class PatchModuleProliferation extends PatchModule {
         // space in neighborhood to divide into. Otherwise, check if double
         // volume has been reached, and if so, create a new cell.
         if (currentHeight > maxHeight) {
-            cell.setState(State.QUIESCENT);
+            if (cell instanceof PatchCellCART) {
+                cell.setState(State.PAUSED);
+            } else {
+                cell.setState(State.QUIESCENT);
+            }
         } else {
             PatchLocation newLocation = cell.selectBestLocation(sim, random);
 
             if (newLocation == null) {
-                cell.setState(State.QUIESCENT);
+                if (cell instanceof PatchCellCART) {
+                    cell.setState(State.PAUSED);
+                } else {
+                    cell.setState(State.QUIESCENT);
+                }
             } else if (cell.getVolume() >= targetVolume) {
                 if (ticker > synthesisDuration) {
 

--- a/src/arcade/patch/agent/process/PatchProcessInflammation.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammation.java
@@ -124,14 +124,14 @@ public abstract class PatchProcessInflammation extends PatchProcess {
      * bound and no three-chain receptors. Daughter cells split amounts of bound IL-2 and
      * three-chain receptors upon dividing.
      *
-     * @param c the {@link PatchCellCART} the module is associated with
+     * @param cell the {@link PatchCellCART} the module is associated with
      */
-    public PatchProcessInflammation(PatchCellCART c) {
-        super(c);
-        this.loc = c.getLocation();
-        this.cell = c;
-        this.pop = c.getPop();
-        this.volume = c.getVolume();
+    public PatchProcessInflammation(PatchCellCART cell) {
+        super(cell);
+        this.loc = cell.getLocation();
+        this.cell = cell;
+        this.pop = cell.getPop();
+        this.volume = cell.getVolume();
         this.iL2Ticker = 0;
         this.activeTicker = 0;
 

--- a/src/arcade/patch/agent/process/PatchProcessInflammation.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammation.java
@@ -311,7 +311,7 @@ public abstract class PatchProcessInflammation extends PatchProcess {
             case "CD4":
                 throw new UnsupportedOperationException();
             case "CD8":
-                throw new UnsupportedOperationException();
+                return new PatchProcessInflammationCD8((PatchCellCART) cell);
             default:
                 return null;
         }

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -27,10 +27,10 @@ public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
      *
      * <p>Initial amount of internal granzyme is set. Granzyme production parameters set.
      *
-     * @param c the {@link PatchCellCART} the module is associated with
+     * @param cell the {@link PatchCellCART} the module is associated with
      */
-    public PatchProcessInflammationCD8(PatchCellCART c) {
-        super(c);
+    public PatchProcessInflammationCD8(PatchCellCART cell) {
+        super(cell);
 
         Parameters parameters = cell.getParameters();
         this.granzSynthesisDelay = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -7,13 +7,13 @@ import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCellCART;
 
 public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
-    /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2] */
+    /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2]. */
     private static final double GRANZ_PER_IL2 = 0.005;
 
-    /** Delay in IL-2 synthesis after antigen-induced activation */
-    private final int GRANZ_SYNTHESIS_DELAY;
+    /** Delay in IL-2 synthesis after antigen-induced activation. */
+    private final int granz_synthesis_delay;
 
-    /** Amount of IL-2 bound in past being used for current granzyme production calculation */
+    /** Amount of IL-2 bound in past being used for current granzyme production calculation. */
     private double priorIL2granz;
 
     /**
@@ -26,36 +26,33 @@ public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
     public PatchProcessInflammationCD8(PatchCellCART c) {
         super(c);
 
-        // Set parameters.
         Parameters parameters = cell.getParameters();
-        this.GRANZ_SYNTHESIS_DELAY = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
+        this.granz_synthesis_delay = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
         this.priorIL2granz = 0;
 
-        // Initialize internal, external, and uptake concentration arrays.
         amts[GRANZYME] = 1; // [molecules]
-
-        // Molecule names.
         names.add(GRANZYME, "granzyme");
     }
 
+    @Override
     public void stepProcess(MersenneTwisterFast random, Simulation sim) {
 
         // Determine amount of granzyme production based on if cell is activated
         // as a function of IL-2 production.
-        int granzIndex = (iL2Ticker % boundArray.length) - GRANZ_SYNTHESIS_DELAY;
+        int granzIndex = (iL2Ticker % boundArray.length) - granz_synthesis_delay;
         if (granzIndex < 0) {
             granzIndex += boundArray.length;
         }
         priorIL2granz = boundArray[granzIndex];
 
-        if (active && activeTicker > GRANZ_SYNTHESIS_DELAY) {
+        if (active && activeTicker > granz_synthesis_delay) {
             amts[GRANZYME] += GRANZ_PER_IL2 * (priorIL2granz / iL2Receptors);
         }
 
         // Update environment.
         // Convert units back from molecules to molecules/cm^3.
-        double IL2Env = ((extIL2 - (extIL2 * fraction - amts[IL2_EXT])) * 1E12 / loc.getVolume());
-        sim.getLattice("IL-2").setValue(loc, IL2Env);
+        double iL2Env = ((extIL2 - (extIL2 * fraction - amts[IL2_EXT])) * 1E12 / loc.getVolume());
+        sim.getLattice("IL-2").setValue(loc, iL2Env);
     }
 
     @Override

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -6,12 +6,18 @@ import arcade.core.sim.Simulation;
 import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCellCART;
 
+/**
+ * Extension of {@link PatchProcessInflammation} for CD8 CAR T-cells
+ *
+ * <p>{@code InflammationCD8} determines granzyme amounts produced for cytotoxic effector functions
+ * as a function of IL-2 bound and antigen-induced activation state.
+ */
 public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
     /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2]. */
     private static final double GRANZ_PER_IL2 = 0.005;
 
     /** Delay in IL-2 synthesis after antigen-induced activation. */
-    private final int granz_synthesis_delay;
+    private final int granzSynthesisDelay;
 
     /** Amount of IL-2 bound in past being used for current granzyme production calculation. */
     private double priorIL2granz;
@@ -27,7 +33,7 @@ public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
         super(c);
 
         Parameters parameters = cell.getParameters();
-        this.granz_synthesis_delay = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
+        this.granzSynthesisDelay = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
         this.priorIL2granz = 0;
 
         amts[GRANZYME] = 1; // [molecules]
@@ -39,13 +45,13 @@ public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
 
         // Determine amount of granzyme production based on if cell is activated
         // as a function of IL-2 production.
-        int granzIndex = (iL2Ticker % boundArray.length) - granz_synthesis_delay;
+        int granzIndex = (iL2Ticker % boundArray.length) - granzSynthesisDelay;
         if (granzIndex < 0) {
             granzIndex += boundArray.length;
         }
         priorIL2granz = boundArray[granzIndex];
 
-        if (active && activeTicker > granz_synthesis_delay) {
+        if (active && activeTicker > granzSynthesisDelay) {
             amts[GRANZYME] += GRANZ_PER_IL2 * (priorIL2granz / iL2Receptors);
         }
 

--- a/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
+++ b/src/arcade/patch/agent/process/PatchProcessInflammationCD8.java
@@ -1,0 +1,92 @@
+package arcade.patch.agent.process;
+
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.process.Process;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+
+public class PatchProcessInflammationCD8 extends PatchProcessInflammation {
+    /** Moles of granzyme produced per moles IL-2 [mol granzyme/mol IL-2] */
+    private static final double GRANZ_PER_IL2 = 0.005;
+
+    /** Delay in IL-2 synthesis after antigen-induced activation */
+    private final int GRANZ_SYNTHESIS_DELAY;
+
+    /** Amount of IL-2 bound in past being used for current granzyme production calculation */
+    private double priorIL2granz;
+
+    /**
+     * Creates a CD8 {@link PatchProcessInflammation} module.
+     *
+     * <p>Initial amount of internal granzyme is set. Granzyme production parameters set.
+     *
+     * @param c the {@link PatchCellCART} the module is associated with
+     */
+    public PatchProcessInflammationCD8(PatchCellCART c) {
+        super(c);
+
+        // Set parameters.
+        Parameters parameters = cell.getParameters();
+        this.GRANZ_SYNTHESIS_DELAY = parameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY");
+        this.priorIL2granz = 0;
+
+        // Initialize internal, external, and uptake concentration arrays.
+        amts[GRANZYME] = 1; // [molecules]
+
+        // Molecule names.
+        names.add(GRANZYME, "granzyme");
+    }
+
+    public void stepProcess(MersenneTwisterFast random, Simulation sim) {
+
+        // Determine amount of granzyme production based on if cell is activated
+        // as a function of IL-2 production.
+        int granzIndex = (iL2Ticker % boundArray.length) - GRANZ_SYNTHESIS_DELAY;
+        if (granzIndex < 0) {
+            granzIndex += boundArray.length;
+        }
+        priorIL2granz = boundArray[granzIndex];
+
+        if (active && activeTicker > GRANZ_SYNTHESIS_DELAY) {
+            amts[GRANZYME] += GRANZ_PER_IL2 * (priorIL2granz / iL2Receptors);
+        }
+
+        // Update environment.
+        // Convert units back from molecules to molecules/cm^3.
+        double IL2Env = ((extIL2 - (extIL2 * fraction - amts[IL2_EXT])) * 1E12 / loc.getVolume());
+        sim.getLattice("IL-2").setValue(loc, IL2Env);
+    }
+
+    @Override
+    public void update(Process mod) {
+        PatchProcessInflammationCD8 inflammation = (PatchProcessInflammationCD8) mod;
+        double split = (this.cell.getVolume() / this.volume);
+
+        // Update daughter cell inflammation as a fraction of parent.
+        this.amts[IL2RBGA] = inflammation.amts[IL2RBGA] * split;
+        this.amts[IL2_IL2RBG] = inflammation.amts[IL2_IL2RBG] * split;
+        this.amts[IL2_IL2RBGA] = inflammation.amts[IL2_IL2RBGA] * split;
+        this.amts[IL2RBG] =
+                iL2Receptors - this.amts[IL2RBGA] - this.amts[IL2_IL2RBG] - this.amts[IL2_IL2RBGA];
+        this.amts[IL2_INT_TOTAL] = this.amts[IL2_IL2RBG] + this.amts[IL2_IL2RBGA];
+        this.amts[IL2R_TOTAL] = this.amts[IL2RBG] + this.amts[IL2RBGA];
+        this.amts[GRANZYME] = inflammation.amts[GRANZYME] * split;
+        this.boundArray = (inflammation.boundArray).clone();
+
+        // Update parent cell with remaining fraction.
+        inflammation.amts[IL2RBGA] *= (1 - split);
+        inflammation.amts[IL2_IL2RBG] *= (1 - split);
+        inflammation.amts[IL2_IL2RBGA] *= (1 - split);
+        inflammation.amts[IL2RBG] =
+                iL2Receptors
+                        - inflammation.amts[IL2RBGA]
+                        - inflammation.amts[IL2_IL2RBG]
+                        - inflammation.amts[IL2_IL2RBGA];
+        inflammation.amts[IL2_INT_TOTAL] =
+                inflammation.amts[IL2_IL2RBG] + inflammation.amts[IL2_IL2RBGA];
+        inflammation.amts[IL2R_TOTAL] = inflammation.amts[IL2RBG] + inflammation.amts[IL2RBGA];
+        inflammation.amts[GRANZYME] *= (1 - split);
+        inflammation.volume *= (1 - split);
+    }
+}

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -43,8 +43,7 @@
     <population id="SELF_ALPHA" value="3" description="fitting factor in PD1 binding function" />
     <population id="SELF_BETA" value="0.02" description="fitting factor in PD1 binding function" />
     <population id="CONTACT_FRAC" value="0.2" description="fraction of cell surface contacting a bound cell during a binding event" />
-    <population id="BOUND_TIME" value="360" description="6 hours" />
-    <population id="BOUND_RANGE" value="0" description="hours" />
+    <population id="BOUND_TIME" value="UNIFORM(MIN=360-0,MAX=360+0)" description="6 hours" />
 
     <!-- proliferation module parameters -->
 

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -89,7 +89,7 @@
     <population.process process="inflammation" id="IL2_RECEPTORS" value="2000" unit="IL-2 receptors/cell" />
 
     <!-- inflammation CD8 module -->
-    <population.process process="inflammation" id="GRANZ_SYNTHESIS_DELAY" value="15" unit="min" />
+    <population.process process="inflammation" id="GRANZ_SYNTHESIS_DELAY" value="15" unit="min" description="Time required for CAR T-cells to maintain bound contact with target antigen before activation signal induces granzyme production"/>
 
     <!-- LAYERS ============================================================ -->
 

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -44,6 +44,8 @@
     <population id="SELF_ALPHA" value="3" description="fitting factor in PD1 binding function" />
     <population id="SELF_BETA" value="0.02" description="fitting factor in PD1 binding function" />
     <population id="CONTACT_FRAC" value="0.2" description="fraction of cell surface contacting a bound cell during a binding event" />
+    <population id="BOUND_TIME" value="360" description="6 hours" />
+    <population id="BOUND_RANGE" value="0" description="hours" />
 
     <!-- proliferation module parameters -->
 
@@ -86,6 +88,9 @@
     <!-- inflammation process module -->
     <population.process process="inflammation" id="SHELL_THICKNESS" value="2.0" unit="um" />
     <population.process process="inflammation" id="IL2_RECEPTORS" value="2000" unit="IL-2 receptors/cell" />
+
+    <!-- inflammation CD8 module -->
+    <population.process process="inflammation" id="GRANZ_SYNTHESIS_DELAY" value="15" unit="min" />
 
     <!-- LAYERS ============================================================ -->
 

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -25,7 +25,6 @@
     <population id="MAX_DENSITY" value="-1" description="maximum amount of cells in location, -1 means no limit" />
     <population id="ACCURACY" value="0.8" description="accuracy to select highest glucose concentration in future location" />
     <population id="AFFINITY" value="0.5" description="movement toward center affinity when selecting future location" />
-    <population id="MAX_DENSITY" value="54" description="maximum amount of cells in location, -1 means no limit" />
     <population id="SYNTHESIS_DURATION" value="637" units="min" description="time required for DNA synthesis" />
 
     <!-- CAR T specific parameters -->

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -26,7 +26,6 @@
     <population id="ACCURACY" value="0.8" description="accuracy to select highest glucose concentration in future location" />
     <population id="AFFINITY" value="0.5" description="movement toward center affinity when selecting future location" />
     <population id="MAX_DENSITY" value="54" description="maximum amount of cells in location, -1 means no limit" />
-    <population id="SYNTHESIS_DURATION" value="637" units="min" description="time required for DNA synthesis" />
 
     <!-- CAR T specific parameters -->
     <population id="ANERGIC_FRACTION" value="0.5" description="fraction of anergic cells that become apoptotic" />

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -43,7 +43,7 @@
     <population id="SELF_ALPHA" value="3" description="fitting factor in PD1 binding function" />
     <population id="SELF_BETA" value="0.02" description="fitting factor in PD1 binding function" />
     <population id="CONTACT_FRAC" value="0.2" description="fraction of cell surface contacting a bound cell during a binding event" />
-    <population id="BOUND_TIME" value="UNIFORM(MIN=360-0,MAX=360+0)" description="6 hours" />
+    <population id="BOUND_TIME" value="360" description="6 hours" />
 
     <!-- proliferation module parameters -->
     <population.module module="proliferation" id="SYNTHESIS_DURATION" value="637" units="min" description="time required for DNA synthesis" />

--- a/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
@@ -156,7 +156,7 @@ public class PatchCellCARTCD8Test {
     }
 
     @Test
-    public void step_whenDivisionPotentialMet_setsStateToSenescent()
+    public void step_whenDivisionPotentialMet_setsStateToApoptotic()
             throws NoSuchFieldException, IllegalAccessException {
         Field div = PatchCell.class.getDeclaredField("divisions");
         div.setAccessible(true);
@@ -166,6 +166,21 @@ public class PatchCellCARTCD8Test {
         cell.step(sim);
 
         assertTrue(cell.getState() == State.APOPTOTIC);
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+        assertFalse(cell.getActivationStatus());
+    }
+
+    @Test
+    public void step_whenDivisionPotentialMet_setsStateToSenescent()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field div = PatchCell.class.getDeclaredField("divisions");
+        div.setAccessible(true);
+        div.set(cell, cell.divisionPotential);
+        when(sim.random.nextDouble()).thenReturn(0.49);
+
+        cell.step(sim);
+
+        assertTrue(cell.getState() == State.SENESCENT);
         assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
         assertFalse(cell.getActivationStatus());
     }

--- a/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
@@ -87,6 +87,7 @@ public class PatchCellCARTCD8Test {
         when(parameters.getInt("CARS")).thenReturn(50000);
         when(parameters.getDouble("APOPTOSIS_AGE")).thenReturn(120960.0);
         when(parameters.getInt("MAX_DENSITY")).thenReturn(54);
+        when(parameters.getInt("DIVISION_POTENTIAL")).thenReturn(10);
 
         cell = spy(new PatchCellCARTCD8(container, location, parameters));
 
@@ -155,11 +156,11 @@ public class PatchCellCARTCD8Test {
     }
 
     @Test
-    public void step_whenDivisionsAreZero_setsStateToSenescent()
+    public void step_whenDivisionPotentialMet_setsStateToSenescent()
             throws NoSuchFieldException, IllegalAccessException {
         Field div = PatchCell.class.getDeclaredField("divisions");
         div.setAccessible(true);
-        div.set(cell, 0);
+        div.set(cell, cell.divisionPotential);
         when(sim.random.nextDouble()).thenReturn(0.51);
 
         cell.step(sim);

--- a/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
@@ -1,0 +1,230 @@
+package arcade.patch.agent.cell;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import sim.engine.Schedule;
+import sim.engine.Steppable;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.MiniBox;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.module.PatchModule;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSignaling;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.Domain;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+import static arcade.core.ARCADETestUtilities.randomIntBetween;
+import static arcade.patch.util.PatchEnums.AntigenFlag;
+import static arcade.patch.util.PatchEnums.State;
+
+public class PatchCellCARTCD8Test {
+
+    private PatchCellCARTCD8 cell;
+    private Parameters parameters;
+    private PatchLocation location;
+    private PatchCellContainer container;
+    PatchSimulation sim;
+
+    @BeforeEach
+    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+        parameters = spy(new Parameters(new MiniBox(), null, null));
+        location = mock(PatchLocation.class);
+
+        int id = 1;
+        int parentId = 1;
+        int pop = 1;
+        int age = randomIntBetween(1, 120950);
+        int divisions = 10;
+        double volume = randomDoubleBetween(100, 200);
+        double height = randomDoubleBetween(4, 10);
+        double criticalVolume = randomDoubleBetween(100, 200);
+        double criticalHeight = randomDoubleBetween(4, 10);
+        State state = State.UNDEFINED;
+
+        container =
+                new PatchCellContainer(
+                        id,
+                        parentId,
+                        pop,
+                        age,
+                        divisions,
+                        state,
+                        volume,
+                        height,
+                        criticalVolume,
+                        criticalHeight);
+
+        doReturn(0.0).when(parameters).getDouble(any(String.class));
+        doReturn(0).when(parameters).getInt(any(String.class));
+        when(parameters.getDouble("HETEROGENEITY")).thenReturn(0.0);
+        when(parameters.getDouble("ENERGY_THRESHOLD")).thenReturn(1.0);
+        when(parameters.getDouble("NECROTIC_FRACTION"))
+                .thenReturn(randomIntBetween(40, 100) / 100.0);
+        when(parameters.getDouble("EXHAU_FRAC")).thenReturn(randomIntBetween(40, 100) / 100.0);
+        when(parameters.getDouble("SENESCENT_FRACTION"))
+                .thenReturn(randomIntBetween(40, 100) / 100.0);
+        when(parameters.getDouble("ANERGIC_FRACTION"))
+                .thenReturn(randomIntBetween(40, 100) / 100.0);
+        when(parameters.getDouble("PROLIFERATIVE_FRACTION"))
+                .thenReturn(randomIntBetween(40, 100) / 100.0);
+        when(parameters.getInt("SELF_RECEPTORS")).thenReturn(randomIntBetween(100, 200));
+        when(parameters.getDouble("SEARCH_ABILITY")).thenReturn(1.0);
+        when(parameters.getDouble("CAR_AFFINITY")).thenReturn(10 * Math.pow(10, -7));
+        when(parameters.getDouble("CAR_ALPHA")).thenReturn(3.0);
+        when(parameters.getDouble("CAR_BETA")).thenReturn(0.01);
+        when(parameters.getDouble("SELF_RECEPTOR_AFFINITY")).thenReturn(7.8E-6);
+        when(parameters.getDouble("SELF_ALPHA")).thenReturn(3.0);
+        when(parameters.getDouble("SELF_BETA")).thenReturn(0.02);
+        when(parameters.getDouble("CONTACT_FRAC")).thenReturn(7.8E-6);
+        when(parameters.getInt("MAX_ANTIGEN_BINDING")).thenReturn(10);
+        when(parameters.getInt("CARS")).thenReturn(50000);
+        when(parameters.getDouble("APOPTOSIS_AGE")).thenReturn(120960.0);
+        when(parameters.getInt("MAX_DENSITY")).thenReturn(54);
+
+        cell = spy(new PatchCellCARTCD8(container, location, parameters));
+
+        sim = mock(PatchSimulation.class);
+        cell.processes.put(Domain.METABOLISM, mock(PatchProcessMetabolism.class));
+        cell.processes.put(Domain.SIGNALING, mock(PatchProcessSignaling.class));
+        cell.processes.put(Domain.INFLAMMATION, mock(PatchProcessInflammation.class));
+        PatchModule module = mock(PatchModule.class);
+        MersenneTwisterFast random = mock(MersenneTwisterFast.class);
+        doAnswer(
+                        invocationOnMock -> {
+                            cell.state = invocationOnMock.getArgument(0);
+                            cell.module = module;
+                            return null;
+                        })
+                .when(cell)
+                .setState(any(State.class));
+        doReturn(new PatchCellTissue(container, location, parameters))
+                .when(cell)
+                .bindTarget(
+                        any(Simulation.class),
+                        any(PatchLocation.class),
+                        any(MersenneTwisterFast.class));
+        sim.random = random;
+        cell.setState(State.UNDEFINED);
+    }
+
+    @Test
+    public void step_called_increasesAge() {
+        int initialAge = cell.getAge();
+
+        cell.step(sim);
+
+        assertEquals(initialAge + 1, cell.getAge());
+    }
+
+    @Test
+    public void step_whenEnergyIsLow_setsStateToApoptotic() {
+        cell.setEnergy(-1 * randomIntBetween(2, 5));
+
+        cell.step(sim);
+
+        assertEquals(State.APOPTOTIC, cell.getState());
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+        assertFalse(cell.getActivationStatus());
+    }
+
+    @Test
+    public void step_whenEnergyIsNegativeAndMoreThanThreshold_setsStateToStarved() {
+        cell.setEnergy(-0.5);
+
+        cell.step(sim);
+
+        assertEquals(State.STARVED, cell.getState());
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+    }
+
+    @Test
+    public void step_whenEnergyIsNegativeAndMoreThanThreshold_setsStateToApoptotic() {
+        cell.setEnergy(-1.5);
+
+        cell.step(sim);
+
+        assertEquals(State.APOPTOTIC, cell.getState());
+    }
+
+    @Test
+    public void step_whenDivisionsAreZero_setsStateToSenescent()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field div = PatchCell.class.getDeclaredField("divisions");
+        div.setAccessible(true);
+        div.set(cell, 0);
+
+        cell.step(sim);
+
+        assertTrue(cell.getState() == State.APOPTOTIC || cell.getState() == State.SENESCENT);
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+        assertFalse(cell.getActivationStatus());
+    }
+
+    @Test
+    public void step_whenBoundToBothAntigenAndSelf_setsStateToAnergic() {
+        cell.setBindingFlag(AntigenFlag.BOUND_ANTIGEN_CELL_RECEPTOR);
+
+        cell.step(sim);
+
+        assertTrue(cell.getState() == State.APOPTOTIC || cell.getState() == State.ANERGIC);
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+        assertFalse(cell.getActivationStatus());
+    }
+
+    @Test
+    public void step_whenBoundToAntigen_setsStateToCytotoxic()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field boundAntigens = PatchCellCART.class.getDeclaredField("boundCARAntigensCount");
+        boundAntigens.setAccessible(true);
+        boundAntigens.set(cell, 0);
+        cell.setBindingFlag(AntigenFlag.BOUND_ANTIGEN);
+        Schedule schedule = mock(Schedule.class);
+        doReturn(true).when(schedule).scheduleOnce(any(Steppable.class));
+        doReturn(schedule).when(sim).getSchedule();
+
+        cell.step(sim);
+
+        verify(cell, times(1)).setState(State.CYTOTOXIC);
+    }
+
+    @Test
+    public void step_whenActivated_setsStateToProliferative()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field active = PatchCellCART.class.getDeclaredField("activated");
+        active.setAccessible(true);
+        active.set(cell, true);
+
+        cell.step(sim);
+
+        assertEquals(State.PROLIFERATIVE, cell.getState());
+    }
+
+    @Test
+    public void step_whenNotActivated_setsStateToMigratory() {
+        cell.step(sim);
+
+        assertTrue(cell.getState() == State.MIGRATORY || cell.getState() == State.PROLIFERATIVE);
+    }
+
+    @Test
+    public void step_whenOverstimulated_setsStateToExhausted()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field boundAntigens = PatchCellCART.class.getDeclaredField("boundCARAntigensCount");
+        boundAntigens.setAccessible(true);
+        boundAntigens.set(cell, cell.maxAntigenBinding + 1);
+        cell.setBindingFlag(AntigenFlag.BOUND_ANTIGEN);
+
+        cell.step(sim);
+
+        assertTrue(cell.getState() == State.APOPTOTIC || cell.getState() == State.EXHAUSTED);
+        assertEquals(AntigenFlag.UNBOUND, cell.getBindingFlag());
+        assertFalse(cell.getActivationStatus());
+    }
+}

--- a/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
@@ -45,7 +45,7 @@ public class PatchCellCARTCD8Test {
         int parentId = 1;
         int pop = 1;
         int age = randomIntBetween(1, 120950);
-        int divisions = 10;
+        int divisions = 0;
         double volume = randomDoubleBetween(100, 200);
         double height = randomDoubleBetween(4, 10);
         double criticalVolume = randomDoubleBetween(100, 200);

--- a/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTCD8Test.java
@@ -27,13 +27,17 @@ import static arcade.patch.util.PatchEnums.State;
 public class PatchCellCARTCD8Test {
 
     private PatchCellCARTCD8 cell;
+
     private Parameters parameters;
+
     private PatchLocation location;
+
     private PatchCellContainer container;
+
     PatchSimulation sim;
 
     @BeforeEach
-    public void setUp() throws NoSuchFieldException, IllegalAccessException {
+    public final void setUp() throws NoSuchFieldException, IllegalAccessException {
         parameters = spy(new Parameters(new MiniBox(), null, null));
         location = mock(PatchLocation.class);
 

--- a/test/arcade/patch/agent/cell/PatchCellCARTTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellCARTTest.java
@@ -199,4 +199,31 @@ public class PatchCellCARTTest {
         activation.set(patchCellCART, true);
         assertTrue(patchCellCART.getActivationStatus());
     }
+
+    @Test
+    public void getBoundTarget_called_returnsTarget()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field target = PatchCellCART.class.getDeclaredField("boundTarget");
+        target.setAccessible(true);
+        target.set(patchCellCART, tissueCell);
+
+        PatchCell targetCell = patchCellCART.getBoundTarget();
+
+        assertEquals(targetCell, tissueCell);
+    }
+
+    @Test
+    public void unbind_called_setsStateAndTarget()
+            throws NoSuchFieldException, IllegalAccessException {
+        patchCellCART.setBindingFlag(PatchEnums.AntigenFlag.BOUND_ANTIGEN);
+        Field target = PatchCellCART.class.getDeclaredField("boundTarget");
+        target.setAccessible(true);
+        target.set(patchCellCART, tissueCell);
+
+        patchCellCART.unbind();
+
+        PatchCell targetCell = patchCellCART.getBoundTarget();
+        assertNull(targetCell);
+        assertEquals(PatchEnums.AntigenFlag.UNBOUND, patchCellCART.getBindingFlag());
+    }
 }

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -26,7 +26,7 @@ public class PatchModuleCytotoxicityTest {
     private MersenneTwisterFast randomMock;
 
     @BeforeEach
-    public void setUp() {
+    public final void setUp() {
         mockCell = mock(PatchCellCART.class);
         mockTarget = mock(PatchCellTissue.class);
         mockInflammation = mock(PatchProcessInflammation.class);

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -1,0 +1,75 @@
+package arcade.patch.agent.module;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ec.util.MersenneTwisterFast;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.State;
+import static org.mockito.Mockito.*;
+
+public class PatchModuleCytotoxicityTest {
+
+    private PatchCellCART mockCell;
+
+    private PatchCellTissue mockTarget;
+
+    private PatchProcessInflammation mockInflammation;
+
+    private PatchModuleCytotoxicity action;
+
+    private PatchSimulation sim;
+
+    private MersenneTwisterFast randomMock;
+
+    @BeforeEach
+    public void setUp() {
+        mockCell = mock(PatchCellCART.class);
+        mockTarget = mock(PatchCellTissue.class);
+        mockInflammation = mock(PatchProcessInflammation.class);
+        sim = mock(PatchSimulation.class);
+        randomMock = mock(MersenneTwisterFast.class);
+        Parameters parameters = mock(Parameters.class);
+        doReturn(0.0).when(parameters).getDouble(any(String.class));
+        doReturn(0).when(parameters).getInt(any(String.class));
+
+        when(mockCell.getParameters()).thenReturn(parameters);
+        when(mockCell.getProcess(any())).thenReturn(mockInflammation);
+        when(mockInflammation.getInternal("granzyme")).thenReturn(1.0);
+        when(mockCell.getBoundTarget()).thenReturn(mockTarget);
+
+        action = new PatchModuleCytotoxicity(mockCell);
+    }
+
+    @Test
+    public void step_CARCellStopped_doesNotChangeCell() {
+        when(mockCell.isStopped()).thenReturn(true);
+        action.step(randomMock, sim);
+
+        verify(mockTarget, never()).setState(any());
+    }
+
+    @Test
+    public void step_targetCellStopped_doesNotChangeCell() {
+        when(mockTarget.isStopped()).thenReturn(true);
+        action.step(randomMock, sim);
+
+        verify(mockTarget, never()).setState(any());
+        verify(mockCell).unbind();
+    }
+
+    @Test
+    public void step_killTargetCell_killsCellAndUsesGranzyme() {
+        when(mockCell.isStopped()).thenReturn(false);
+        when(mockTarget.isStopped()).thenReturn(false);
+        PatchModuleApoptosis mockProcess = mock(PatchModuleApoptosis.class);
+        when(mockTarget.getModule()).thenReturn(mockProcess);
+        action.step(randomMock, sim);
+
+        verify(mockTarget).setState(State.APOPTOTIC);
+        verify(mockInflammation).setInternal("granzyme", 0.0);
+    }
+}

--- a/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
+++ b/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
@@ -1,0 +1,154 @@
+package arcade.patch.agent.process;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import ec.util.MersenneTwisterFast;
+import arcade.core.sim.Simulation;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCellCART;
+import arcade.patch.env.lattice.PatchLattice;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.randomDoubleBetween;
+
+public class PatchProcessInflammationCD8Test {
+
+    private PatchProcessInflammationCD8 inflammation;
+
+    private PatchCellCART mockCell;
+
+    private Parameters mockParameters;
+
+    private Simulation mockSimulation;
+
+    private MersenneTwisterFast mockRandom;
+
+    private double cellVolume;
+
+    @BeforeEach
+    public final void setUp() {
+        mockCell = Mockito.mock(PatchCellCART.class);
+        mockParameters = Mockito.mock(Parameters.class);
+        mockSimulation = Mockito.mock(Simulation.class);
+        mockRandom = Mockito.mock(MersenneTwisterFast.class);
+        PatchLocation mockLocation = mock(PatchLocation.class);
+        PatchLattice mockLattice = mock(PatchLattice.class);
+
+        Mockito.when(mockCell.getParameters()).thenReturn(mockParameters);
+        cellVolume = randomDoubleBetween(165, 180);
+        when(mockCell.getVolume()).thenReturn(cellVolume);
+        when(mockCell.getLocation()).thenReturn(mockLocation);
+        when(mockLocation.getVolume()).thenReturn(3.0 / 2.0 / Math.sqrt(3.0) * 30 * 30 * 8.7);
+        when(mockParameters.getDouble(anyString())).thenReturn(1.0);
+        when(mockParameters.getInt(anyString())).thenReturn(1);
+
+        when(mockSimulation.getLattice(anyString())).thenReturn(mockLattice);
+        doNothing().when(mockLattice).setValue(any(PatchLocation.class), anyDouble());
+    }
+
+    @Test
+    public void constructor_setsParameters() throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        assertNotNull(inflammation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+
+        Field prior = PatchProcessInflammationCD8.class.getDeclaredField("priorIL2granz");
+        prior.setAccessible(true);
+        assertEquals(0.0, prior.get(inflammation));
+
+        Field delay = PatchProcessInflammationCD8.class.getDeclaredField("granzSynthesisDelay");
+        delay.setAccessible(true);
+        assertEquals(1, delay.get(inflammation));
+    }
+
+    @Test
+    public void stepProcess_updatesEnvironment()
+            throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = true;
+        inflammation.activeTicker = 10;
+        inflammation.iL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("iL2Receptors");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertTrue(inflammation.amts[PatchProcessInflammationCD8.GRANZYME] > 1);
+    }
+
+    @Test
+    public void stepProcess_whenInactive_returnsDefaultRate()
+            throws NoSuchFieldException, IllegalAccessException {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = false;
+        inflammation.activeTicker = 10;
+        inflammation.iL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("iL2Receptors");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void stepProcess_activeTickerLessThanDelay_usesDefaultRate()
+            throws NoSuchFieldException, IllegalAccessException {
+        Mockito.when(mockParameters.getInt("inflammation/GRANZ_SYNTHESIS_DELAY")).thenReturn(5);
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        inflammation.active = true;
+        inflammation.activeTicker = 3;
+        inflammation.iL2Ticker = 10;
+        inflammation.boundArray = new double[180];
+        Arrays.fill(inflammation.boundArray, 10000);
+
+        Field receptors = PatchProcessInflammation.class.getDeclaredField("iL2Receptors");
+        receptors.setAccessible(true);
+        receptors.set(inflammation, 5000);
+
+        inflammation.stepProcess(mockRandom, mockSimulation);
+
+        assertEquals(1, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void update_evenSplit_splitsEvenly() {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        PatchProcessInflammationCD8 parentProcess = new PatchProcessInflammationCD8(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD8.GRANZYME] = 100;
+        when(mockCell.getVolume()).thenReturn(cellVolume / 2);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(50, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+        assertEquals(50, parentProcess.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+
+    @Test
+    public void update_withZeroVolume_splitsUnevenly() {
+        inflammation = new PatchProcessInflammationCD8(mockCell);
+        PatchProcessInflammationCD8 parentProcess = new PatchProcessInflammationCD8(mockCell);
+        parentProcess.amts[PatchProcessInflammationCD8.GRANZYME] = 100;
+        when(mockCell.getVolume()).thenReturn(0.0);
+
+        inflammation.update(parentProcess);
+
+        assertEquals(0, inflammation.amts[PatchProcessInflammationCD8.GRANZYME]);
+        assertEquals(100, parentProcess.amts[PatchProcessInflammationCD8.GRANZYME]);
+    }
+}

--- a/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
+++ b/test/arcade/patch/agent/process/PatchProcessInflammationCD8Test.java
@@ -53,7 +53,8 @@ public class PatchProcessInflammationCD8Test {
     }
 
     @Test
-    public void constructor_setsParameters() throws NoSuchFieldException, IllegalAccessException {
+    public void constructor_called_setsParameters()
+            throws NoSuchFieldException, IllegalAccessException {
         inflammation = new PatchProcessInflammationCD8(mockCell);
         assertNotNull(inflammation);
 
@@ -69,7 +70,7 @@ public class PatchProcessInflammationCD8Test {
     }
 
     @Test
-    public void stepProcess_updatesEnvironment()
+    public void stepProcess_called_updatesEnvironment()
             throws NoSuchFieldException, IllegalAccessException {
         inflammation = new PatchProcessInflammationCD8(mockCell);
         inflammation.active = true;


### PR DESCRIPTION
Addresses #40

_Estimated Time: medium_ 

**Overview of major changes:**
This PR is meant to add in the T Cell CD8 agent and the associated inflammation process. Major changes:

- Added switch statements to setState() function in `PatchCell` to add in cytotoxic states
-  Rerouted quiescent state to paused in proliferation, migration modules
- Added Cytotoxic module
- Added accessory methods to PatchCellCART class
- Added PatchCellCARTCD8 class
- Added PatchProcessInflammationCD8 classes

## Detailed breakdown of changes

### Patch Cell Classes 

`PatchCell` class:
- addition of cytotoxic module switch statement
- addition of exception thrown for QUIESCENT 

`PatchCellContainer` class:
- added option for CD8 cells 

### CART Agents and associated classes 

`PatchCellCART`
- added boundTarget as a field to accommodate for T cell target tracking
- added getBoundTarget to retrieve the target cell
- unbind() method to reset binding state 

`PatchCellCARTTest`
- added unit tests for addition of methods above

`PatchCellCARTCD8`
- added agent class and rules 

`PatchCellCARTCD8Test`
- added unit tests for the agent class to verify functionality

### Modules
`PatchModuleCytotoxicity` class:
- added module to help kill targets and reset T cell

`PatchModuleCytotoxicityTest` class:
- added unit tests for the class to verify functionality 

### Inflammation Process
`PatchProcessInflammation` class:
- added option to make cd8 inflammation process 

`PatchProcessInflammationCD8Test` class:
- added unit tests for the class to verify functionality 

### Parameters 
`parameter.patch.xml`
- added inflammation parameters
- added cytotoxic module parameters
