### PR TITLE
Bugfix for edgecase: if current location is not free and all locations are further away, when affinity is = 1

### DIFF
--- a/src/arcade/core/util/GrabBag.java
+++ b/src/arcade/core/util/GrabBag.java
@@ -56,6 +56,10 @@ public class GrabBag {
         return map.higherEntry(value).getValue();
     }
 
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
     /**
      * Gets hash based on total weight and mapping.
      *

--- a/src/arcade/core/util/GrabBag.java
+++ b/src/arcade/core/util/GrabBag.java
@@ -56,7 +56,6 @@ public class GrabBag {
         return map.higherEntry(value).getValue();
     }
 
-
     /**
      * Checks if the bag is empty.
      *

--- a/src/arcade/core/util/GrabBag.java
+++ b/src/arcade/core/util/GrabBag.java
@@ -56,6 +56,12 @@ public class GrabBag {
         return map.higherEntry(value).getValue();
     }
 
+
+    /**
+     * Checks if the bag is empty.
+     *
+     * @return {@code true} if bag is empty, {@code false} otherwise
+     */
     public boolean isEmpty() {
         return map.isEmpty();
     }

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -460,10 +460,12 @@ public abstract class PatchCell implements Cell {
                     options.add(inds[i], 1);
                 }
             }
-            return (PatchLocation) locs.get(options.next(random));
-        } else {
-            return null;
-        }
+            if (!options.isEmpty()) { 
+                return (PatchLocation) locs.get(options.next(random));
+            }
+        } 
+
+        return null;
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -460,10 +460,10 @@ public abstract class PatchCell implements Cell {
                     options.add(inds[i], 1);
                 }
             }
-            if (!options.isEmpty()) { 
+            if (!options.isEmpty()) {
                 return (PatchLocation) locs.get(options.next(random));
             }
-        } 
+        }
 
         return null;
     }

--- a/test/arcade/patch/agent/cell/PatchCellTest.java
+++ b/test/arcade/patch/agent/cell/PatchCellTest.java
@@ -482,6 +482,42 @@ public class PatchCellTest {
     }
 
     @Test
+    public void selectBestLocation_calledWithMaxAffinityAndNoCloserLocation_returnNull() {
+        doReturn(0.0).when(parametersMock).getDouble(any(String.class));
+        doReturn(0).when(parametersMock).getInt(any(String.class));
+        doReturn(1.0).when(parametersMock).getDouble("AFFINITY");
+        doReturn(0.0).when(parametersMock).getDouble("ACCURACY");
+        doReturn(0.5).when(randomMock).nextDouble();
+        PatchLattice latticeMock = mock(PatchLattice.class);
+        MiniBox boxMock = mock(MiniBox.class);
+        doReturn(boxMock).when(latticeMock).getParameters();
+        doReturn(latticeMock).when(simMock).getLattice("GLUCOSE");
+        doReturn(100.).when(boxMock).getDouble("generator/CONCENTRATION");
+        PatchCell cell = spy(new PatchCellMock(baseContainer, locationMock, parametersMock));
+        PatchLocation otherLocation1 = mock(PatchLocation.class);
+        PatchLocation otherLocation2 = mock(PatchLocation.class);
+
+        doReturn(1).when(locationMock).getPlanarIndex();
+        doReturn(1).when(otherLocation1).getPlanarIndex();
+        doReturn(1).when(otherLocation2).getPlanarIndex();
+        doReturn(50.).when(latticeMock).getAverageValue(locationMock);
+        doReturn(75.).when(latticeMock).getAverageValue(otherLocation1);
+        doReturn(25.).when(latticeMock).getAverageValue(otherLocation2);
+        doReturn(0.).when(locationMock).getPlanarDistance();
+        doReturn(1.).when(otherLocation1).getPlanarDistance();
+        doReturn(1.).when(otherLocation2).getPlanarDistance();
+
+        Bag locations = new Bag();
+        locations.add(otherLocation1);
+        locations.add(otherLocation2);
+        doReturn(locations).when(cell).findFreeLocations(simMock);
+
+        PatchLocation bestLocation = cell.selectBestLocation(simMock, randomMock);
+
+        assertEquals(bestLocation, null);
+    }
+
+    @Test
     public void selectBestLocation_calledWithNoFreeLocations_returnsNull() {
         doReturn(0.0).when(parametersMock).getDouble(any(String.class));
         doReturn(0).when(parametersMock).getInt(any(String.class));


### PR DESCRIPTION
If all free locations are +1 planar distance from the current location, the score would remain 0 for all proposed locations.  

_estimated size_: small

Proposed fix: return no best locations (null) if the affinity of the cell is equal to 1.0 if all of the available locations are further away from the current location, leading to a quiescent state change.

Resolves #158.

Changes: 
- Returns Null if no closer locations in `selectBestLocation` 
- Added public `isEmpty()` method to `GrabBag` class