### PR TITLE
Bugfix: vasculature generation 

### DIFF
--- a/src/arcade/core/util/Graph.java
+++ b/src/arcade/core/util/Graph.java
@@ -14,7 +14,9 @@ import sim.util.Bag;
 /**
  * Container class for directed graph using nodes as hashes.
  *
- * <p>{@code Edge} objects represent edges in the graph and {@code Node} objects represent nodes in
+ * <p>
+ * {@code Edge} objects represent edges in the graph and {@code Node} objects
+ * represent nodes in
  * the graph. Nodes may have more than one edge in or out.
  */
 public final class Graph {
@@ -103,7 +105,7 @@ public final class Graph {
     /**
      * Gets all edges in the graph based on the given node and category.
      *
-     * @param node the node to get edges from
+     * @param node     the node to get edges from
      * @param strategy the category of edges to get
      * @return a bag containing the edges
      */
@@ -165,7 +167,7 @@ public final class Graph {
      * Checks if the graph has an edge between the given nodes.
      *
      * @param from the node the edge points from
-     * @param to the node the edge points to
+     * @param to   the node the edge points to
      * @return {@code true} if edge exists, {@code false} otherwise
      */
     public boolean hasEdge(Node from, Node to) {
@@ -197,7 +199,8 @@ public final class Graph {
     /**
      * Filters this graph for edges and copies them to the given graph object.
      *
-     * <p>Notes that the links in the subgraph are not correct.
+     * <p>
+     * Notes that the links in the subgraph are not correct.
      *
      * @param g the graph to add filtered edges to
      * @param f the edge filter
@@ -221,13 +224,12 @@ public final class Graph {
     private Set<Node> retrieveNodes() {
         Set<Node> sOut = nodeToOutBag.keySet();
         Set<Node> sIn = nodeToInBag.keySet();
-        Set<Node> set =
-                new LinkedHashSet<Node>() {
-                    {
-                        addAll(sOut);
-                        addAll(sIn);
-                    }
-                };
+        Set<Node> set = new LinkedHashSet<Node>() {
+            {
+                addAll(sOut);
+                addAll(sIn);
+            }
+        };
 
         return set;
     }
@@ -262,7 +264,7 @@ public final class Graph {
      * Adds edge to graph based on nodes.
      *
      * @param from the node to add as the from node.
-     * @param to the node to add as the to node.
+     * @param to   the node to add as the to node.
      */
     public void addEdge(Node from, Node to) {
         addEdge(new Edge(from, to));
@@ -440,11 +442,12 @@ public final class Graph {
     }
 
     /**
-     * Find the first node where two edges intersect based on a calulcation strategy (upstream or
+     * Find the first node where two edges intersect based on a calulcation strategy
+     * (upstream or
      * downstream).
      *
-     * @param edge1 first edge to start from
-     * @param edge2 second edge to start from
+     * @param edge1    first edge to start from
+     * @param edge2    second edge to start from
      * @param strategy the direction to search
      * @return the intersection node or null if no intersection
      */
@@ -461,10 +464,11 @@ public final class Graph {
     }
 
     /**
-     * Get all nodes connected to the given node based on a calculation strategy (e.g. upstream or
+     * Get all nodes connected to the given node based on a calculation strategy
+     * (e.g. upstream or
      * downstream).
      *
-     * @param node the node to start from
+     * @param node     the node to start from
      * @param strategy the direction to search
      * @return a bag of connected nodes
      */
@@ -497,11 +501,12 @@ public final class Graph {
     }
 
     /**
-     * Breadth first search from node according to strategy for a subset of target nodes.
+     * Breadth first search from node according to strategy for a subset of target
+     * nodes.
      *
-     * @param node the node to start from
+     * @param node        the node to start from
      * @param targetNodes the bag of potential intersection nodes
-     * @param strategy the direction to search
+     * @param strategy    the direction to search
      * @return the target node or null if not found
      */
     private Node breadthFirstSearch(Node node, Bag targetNodes, Strategy strategy) {
@@ -587,7 +592,8 @@ public final class Graph {
     /**
      * Nested class representing a graph node.
      *
-     * <p>The node tracks its corresponding position in the lattice.
+     * <p>
+     * The node tracks its corresponding position in the lattice.
      */
     public static class Node implements Comparable<Node> {
         /** Coordinate in x direction. */
@@ -643,8 +649,9 @@ public final class Graph {
          * Compares a node to this node.
          *
          * @param node the node to compare
-         * @return zero if the x and y coordinates are equal, otherwise the result of integer
-         *     comparison for x and y
+         * @return zero if the x and y coordinates are equal, otherwise the result of
+         *         integer
+         *         comparison for x and y
          */
         public int compareTo(Node node) {
             int xComp = Integer.compare(x, node.getX());
@@ -667,7 +674,8 @@ public final class Graph {
         }
 
         /**
-         * Updates the position of this {@code Node} with coordinate from given {@code Node}.
+         * Updates the position of this {@code Node} with coordinate from given
+         * {@code Node}.
          *
          * @param node the {@code Node} with coordinates to update with
          */
@@ -683,7 +691,7 @@ public final class Graph {
          * @return a hash based on coordinates
          */
         public final int hashCode() {
-            return x + y << 8 + z << 16;
+            return x + (y << 8) + (z << 16);
         }
 
         /**
@@ -713,7 +721,9 @@ public final class Graph {
     /**
      * Nested class representing a graph edge.
      *
-     * <p>The edge tracks its corresponding nodes as well as the edges into the FROM node and out of
+     * <p>
+     * The edge tracks its corresponding nodes as well as the edges into the FROM
+     * node and out of
      * the TO node.
      */
     public static class Edge {
@@ -733,7 +743,7 @@ public final class Graph {
          * Creates an {@code Edge} between two {@link Node} objects.
          *
          * @param from the node the edge is from
-         * @param to the node the edge is to
+         * @param to   the node the edge is to
          */
         public Edge(Node from, Node to) {
             this.from = from.duplicate();
@@ -743,7 +753,8 @@ public final class Graph {
         }
 
         /**
-         * Gets the node the edge points to based on the calculation strategy (e.g. upstream or
+         * Gets the node the edge points to based on the calculation strategy (e.g.
+         * upstream or
          * downstream).
          *
          * @param strategy the calculation strategy
@@ -790,7 +801,8 @@ public final class Graph {
         }
 
         /**
-         * Gets list of edges based on calculation strategy (e.g. upstream or downstream).
+         * Gets list of edges based on calculation strategy (e.g. upstream or
+         * downstream).
          *
          * @param strategy the calculation strategy
          * @return the list of edges
@@ -849,7 +861,8 @@ public final class Graph {
          * Checks if two nodes are equal based on to and from nodes.
          *
          * @param obj the object to check
-         * @return {@code true} if coordinates of both nodes match, {@code false} otherwise
+         * @return {@code true} if coordinates of both nodes match, {@code false}
+         *         otherwise
          */
         public boolean equals(Object obj) {
             if (obj instanceof Edge) {
@@ -865,7 +878,7 @@ public final class Graph {
          * @return a hash based on coordinates
          */
         public final int hashCode() {
-            return this.from.hashCode() + this.to.hashCode() << 16;
+            return this.from.hashCode() + (this.to.hashCode() << 16);
         }
     }
 }

--- a/src/arcade/core/util/Graph.java
+++ b/src/arcade/core/util/Graph.java
@@ -14,9 +14,7 @@ import sim.util.Bag;
 /**
  * Container class for directed graph using nodes as hashes.
  *
- * <p>
- * {@code Edge} objects represent edges in the graph and {@code Node} objects
- * represent nodes in
+ * <p>{@code Edge} objects represent edges in the graph and {@code Node} objects represent nodes in
  * the graph. Nodes may have more than one edge in or out.
  */
 public final class Graph {
@@ -105,7 +103,7 @@ public final class Graph {
     /**
      * Gets all edges in the graph based on the given node and category.
      *
-     * @param node     the node to get edges from
+     * @param node the node to get edges from
      * @param strategy the category of edges to get
      * @return a bag containing the edges
      */
@@ -167,7 +165,7 @@ public final class Graph {
      * Checks if the graph has an edge between the given nodes.
      *
      * @param from the node the edge points from
-     * @param to   the node the edge points to
+     * @param to the node the edge points to
      * @return {@code true} if edge exists, {@code false} otherwise
      */
     public boolean hasEdge(Node from, Node to) {
@@ -199,8 +197,7 @@ public final class Graph {
     /**
      * Filters this graph for edges and copies them to the given graph object.
      *
-     * <p>
-     * Notes that the links in the subgraph are not correct.
+     * <p>Notes that the links in the subgraph are not correct.
      *
      * @param g the graph to add filtered edges to
      * @param f the edge filter
@@ -224,12 +221,13 @@ public final class Graph {
     private Set<Node> retrieveNodes() {
         Set<Node> sOut = nodeToOutBag.keySet();
         Set<Node> sIn = nodeToInBag.keySet();
-        Set<Node> set = new LinkedHashSet<Node>() {
-            {
-                addAll(sOut);
-                addAll(sIn);
-            }
-        };
+        Set<Node> set =
+                new LinkedHashSet<Node>() {
+                    {
+                        addAll(sOut);
+                        addAll(sIn);
+                    }
+                };
 
         return set;
     }
@@ -264,7 +262,7 @@ public final class Graph {
      * Adds edge to graph based on nodes.
      *
      * @param from the node to add as the from node.
-     * @param to   the node to add as the to node.
+     * @param to the node to add as the to node.
      */
     public void addEdge(Node from, Node to) {
         addEdge(new Edge(from, to));
@@ -442,12 +440,11 @@ public final class Graph {
     }
 
     /**
-     * Find the first node where two edges intersect based on a calulcation strategy
-     * (upstream or
+     * Find the first node where two edges intersect based on a calulcation strategy (upstream or
      * downstream).
      *
-     * @param edge1    first edge to start from
-     * @param edge2    second edge to start from
+     * @param edge1 first edge to start from
+     * @param edge2 second edge to start from
      * @param strategy the direction to search
      * @return the intersection node or null if no intersection
      */
@@ -464,11 +461,10 @@ public final class Graph {
     }
 
     /**
-     * Get all nodes connected to the given node based on a calculation strategy
-     * (e.g. upstream or
+     * Get all nodes connected to the given node based on a calculation strategy (e.g. upstream or
      * downstream).
      *
-     * @param node     the node to start from
+     * @param node the node to start from
      * @param strategy the direction to search
      * @return a bag of connected nodes
      */
@@ -501,12 +497,11 @@ public final class Graph {
     }
 
     /**
-     * Breadth first search from node according to strategy for a subset of target
-     * nodes.
+     * Breadth first search from node according to strategy for a subset of target nodes.
      *
-     * @param node        the node to start from
+     * @param node the node to start from
      * @param targetNodes the bag of potential intersection nodes
-     * @param strategy    the direction to search
+     * @param strategy the direction to search
      * @return the target node or null if not found
      */
     private Node breadthFirstSearch(Node node, Bag targetNodes, Strategy strategy) {
@@ -592,8 +587,7 @@ public final class Graph {
     /**
      * Nested class representing a graph node.
      *
-     * <p>
-     * The node tracks its corresponding position in the lattice.
+     * <p>The node tracks its corresponding position in the lattice.
      */
     public static class Node implements Comparable<Node> {
         /** Coordinate in x direction. */
@@ -649,9 +643,8 @@ public final class Graph {
          * Compares a node to this node.
          *
          * @param node the node to compare
-         * @return zero if the x and y coordinates are equal, otherwise the result of
-         *         integer
-         *         comparison for x and y
+         * @return zero if the x and y coordinates are equal, otherwise the result of integer
+         *     comparison for x and y
          */
         public int compareTo(Node node) {
             int xComp = Integer.compare(x, node.getX());
@@ -674,8 +667,7 @@ public final class Graph {
         }
 
         /**
-         * Updates the position of this {@code Node} with coordinate from given
-         * {@code Node}.
+         * Updates the position of this {@code Node} with coordinate from given {@code Node}.
          *
          * @param node the {@code Node} with coordinates to update with
          */
@@ -721,9 +713,7 @@ public final class Graph {
     /**
      * Nested class representing a graph edge.
      *
-     * <p>
-     * The edge tracks its corresponding nodes as well as the edges into the FROM
-     * node and out of
+     * <p>The edge tracks its corresponding nodes as well as the edges into the FROM node and out of
      * the TO node.
      */
     public static class Edge {
@@ -743,7 +733,7 @@ public final class Graph {
          * Creates an {@code Edge} between two {@link Node} objects.
          *
          * @param from the node the edge is from
-         * @param to   the node the edge is to
+         * @param to the node the edge is to
          */
         public Edge(Node from, Node to) {
             this.from = from.duplicate();
@@ -753,8 +743,7 @@ public final class Graph {
         }
 
         /**
-         * Gets the node the edge points to based on the calculation strategy (e.g.
-         * upstream or
+         * Gets the node the edge points to based on the calculation strategy (e.g. upstream or
          * downstream).
          *
          * @param strategy the calculation strategy
@@ -801,8 +790,7 @@ public final class Graph {
         }
 
         /**
-         * Gets list of edges based on calculation strategy (e.g. upstream or
-         * downstream).
+         * Gets list of edges based on calculation strategy (e.g. upstream or downstream).
          *
          * @param strategy the calculation strategy
          * @return the list of edges
@@ -861,8 +849,7 @@ public final class Graph {
          * Checks if two nodes are equal based on to and from nodes.
          *
          * @param obj the object to check
-         * @return {@code true} if coordinates of both nodes match, {@code false}
-         *         otherwise
+         * @return {@code true} if coordinates of both nodes match, {@code false} otherwise
          */
         public boolean equals(Object obj) {
             if (obj instanceof Edge) {

--- a/src/arcade/core/util/Graph.java
+++ b/src/arcade/core/util/Graph.java
@@ -278,7 +278,6 @@ public final class Graph {
         setOutMap(edge.getFrom(), edge);
         setInMap(edge.getTo(), edge);
         setLinks(edge);
-        mergeNodes();
     }
 
     /**
@@ -866,7 +865,7 @@ public final class Graph {
          * @return a hash based on coordinates
          */
         public final int hashCode() {
-            return this.from.hashCode() << 16 + this.to.hashCode() << 16;
+            return this.from.hashCode() + this.to.hashCode() << 16;
         }
     }
 }

--- a/src/arcade/potts/env/location/Voxel.java
+++ b/src/arcade/potts/env/location/Voxel.java
@@ -5,18 +5,18 @@ import java.util.Comparator;
 /**
  * Representation of a voxel for locations.
  *
- * <p>Each voxel is defined by (x, y, z) coordinates. Two voxels objects are considered equal if
+ * <p>
+ * Each voxel is defined by (x, y, z) coordinates. Two voxels objects are
+ * considered equal if
  * they have matching (x, y, z) coordinates.
  */
 public final class Voxel {
     /** Comparator for voxels. */
-    public static final Comparator<Voxel> VOXEL_COMPARATOR =
-            (v1, v2) ->
-                    v1.z != v2.z
-                            ? Integer.compare(v1.z, v2.z)
-                            : v1.x != v2.x
-                                    ? Integer.compare(v1.x, v2.x)
-                                    : Integer.compare(v1.y, v2.y);
+    public static final Comparator<Voxel> VOXEL_COMPARATOR = (v1, v2) -> v1.z != v2.z
+            ? Integer.compare(v1.z, v2.z)
+            : v1.x != v2.x
+                    ? Integer.compare(v1.x, v2.x)
+                    : Integer.compare(v1.y, v2.y);
 
     /** Voxel x coordinate. */
     public final int x;

--- a/src/arcade/potts/env/location/Voxel.java
+++ b/src/arcade/potts/env/location/Voxel.java
@@ -5,18 +5,18 @@ import java.util.Comparator;
 /**
  * Representation of a voxel for locations.
  *
- * <p>
- * Each voxel is defined by (x, y, z) coordinates. Two voxels objects are
- * considered equal if
+ * <p>Each voxel is defined by (x, y, z) coordinates. Two voxels objects are considered equal if
  * they have matching (x, y, z) coordinates.
  */
 public final class Voxel {
     /** Comparator for voxels. */
-    public static final Comparator<Voxel> VOXEL_COMPARATOR = (v1, v2) -> v1.z != v2.z
-            ? Integer.compare(v1.z, v2.z)
-            : v1.x != v2.x
-                    ? Integer.compare(v1.x, v2.x)
-                    : Integer.compare(v1.y, v2.y);
+    public static final Comparator<Voxel> VOXEL_COMPARATOR =
+            (v1, v2) ->
+                    v1.z != v2.z
+                            ? Integer.compare(v1.z, v2.z)
+                            : v1.x != v2.x
+                                    ? Integer.compare(v1.x, v2.x)
+                                    : Integer.compare(v1.y, v2.y);
 
     /** Voxel x coordinate. */
     public final int x;

--- a/test/arcade/core/util/GraphTest.java
+++ b/test/arcade/core/util/GraphTest.java
@@ -148,7 +148,7 @@ public class GraphTest {
 
         assertAll(
                 () -> assertTrue(edge0.hashCode() == edge2.hashCode()),
-                () -> assertFalse(edge0.hashCode() != edge1.hashCode()));
+                () -> assertFalse(edge0.hashCode() == edge1.hashCode()));
     }
 
     @Test

--- a/test/arcade/core/util/GraphTest.java
+++ b/test/arcade/core/util/GraphTest.java
@@ -186,7 +186,6 @@ public class GraphTest {
         Edge edge = new Edge(node1, node2);
 
         graph.addEdge(edge);
-
         assertAll(
                 () -> assertTrue(graph.contains(node1)),
                 () -> assertTrue(graph.contains(node2)),


### PR DESCRIPTION
removed mergeNodes that propogated an incorrect node (specifically to an end node) when called when adding a reversed edge. However, I don't think it makes sense to prevent mergeNodes calls, so I haven't added in a graph check to determine whether or not it would break assumptions that happen downstream (specifically in GraphSites). 

estimated size: _xsmall_. 

summary of changes: 
- removed `mergeNodes` call in `addEdge`.
- changed hash code for edges to actually be unique
- fixed hash codes for nodes