### PR TITLE
HOTFIX: fixing edge case in cytotoxic module when time delay is 0

### DIFF
--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -69,7 +69,9 @@ public class PatchModuleCytotoxicity extends PatchModule {
                 granzyme--;
                 inflammation.setInternal("granzyme", granzyme);
             }
-        } else if (ticker >= timeDelay) {
+        }
+
+        if (ticker >= timeDelay) {
             ((PatchCellCART) cell).unbind();
             cell.setState(State.UNDEFINED);
         }

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -70,6 +70,7 @@ public class PatchModuleCytotoxicityTest {
         action.step(randomMock, sim);
 
         verify(mockTarget).setState(State.APOPTOTIC);
+        verify(mockCell).setState(State.UNDEFINED);
         verify(mockInflammation).setInternal("granzyme", 0.0);
     }
 }

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -1,5 +1,6 @@
 package arcade.patch.agent.module;
 
+import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import ec.util.MersenneTwisterFast;
@@ -72,5 +73,18 @@ public class PatchModuleCytotoxicityTest {
         verify(mockTarget).setState(State.APOPTOTIC);
         verify(mockCell).setState(State.UNDEFINED);
         verify(mockInflammation).setInternal("granzyme", 0.0);
+    }
+
+    @Test
+    public void step_timeDelayNotReached_doesNotChangeCell()
+            throws IllegalAccessException, NoSuchFieldException {
+        Field delay = PatchModuleCytotoxicity.class.getDeclaredField("timeDelay");
+        delay.setAccessible(true);
+        delay.set(action, 1);
+
+        action.step(randomMock, sim);
+
+        verify(mockCell, never()).setState(any());
+        verify(mockCell, never()).unbind();
     }
 }


### PR DESCRIPTION
_Estimated Review Time_: very small

**Problem statement:** In the previous version of the code, when the time delay is 0, the second branch would not be reached, even when the expected behavior is that the cell should immediately reset because there is no delay. 

**Proposed fix**: I got rid of the else/if branch and made it just an if statement so that the second branch could be entered even when the time delay is 0. I also added in another check in the test that would catch this bug. 