### PR TITLE
Overload Split function the neuroblasts will use

### DIFF
--- a/src/arcade/core/util/Plane.java
+++ b/src/arcade/core/util/Plane.java
@@ -22,6 +22,24 @@ public final class Plane {
     }
 
     /**
+     * Returns the reference point on the plane.
+     *
+     * @return the reference point on the plane
+     */
+    public Double3D getReferencePoint() {
+        return referencePoint;
+    }
+
+    /**
+     * Returns the unit normal vector to the plane.
+     *
+     * @return the unit normal vector to the plane
+     */
+    public Vector getUnitNormalVector() {
+        return unitNormalVector;
+    }
+
+    /**
      * Determines distance from a point to the plane.
      *
      * <p>The distance is positive if the point is on the same side of the plane as the normal

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -346,6 +346,20 @@ public abstract class PottsLocation implements Location {
      * Splits location voxels into two lists.
      *
      * <p>The location is split along the provided plane. One of the splits is assigned to the
+     * current location and the other is returned with the default split probability.
+     *
+     * @param random the seeded random number generator
+     * @param plane the plane of the split
+     * @return a location with the split voxels
+     */
+    public Location split(MersenneTwisterFast random, Plane plane) {
+        return split(random, plane, DEFAULT_SPLIT_SELECTION_PROBABILITY);
+    }
+
+    /**
+     * Splits location voxels into two lists.
+     *
+     * <p>The location is split along the provided plane. One of the splits is assigned to the
      * current location and the other is returned with the given probability.
      *
      * <p>If the plane of division is through the center of the location, the resulting lists are
@@ -367,7 +381,7 @@ public abstract class PottsLocation implements Location {
         connectVoxels(voxelsA, voxelsB, this, random);
 
         Voxel locCenter = getCenter();
-        if (plane.referencePoint.equals(locCenter)) {
+        if (plane.getReferencePoint().equals(locCenter)) {
             balanceVoxels(voxelsA, voxelsB, this, random);
         }
 

--- a/test/arcade/core/util/PlaneTest.java
+++ b/test/arcade/core/util/PlaneTest.java
@@ -47,6 +47,22 @@ public class PlaneTest {
     }
 
     @Test
+    public void getReferencePoint_givenPlane_returnsCorrectPoint() {
+        Double3D point = new Double3D(1, 2, 3);
+        Vector normalVector = new Vector(1, 0, 0);
+        Plane plane = new Plane(point, normalVector);
+        assertEquals(point, plane.getReferencePoint());
+    }
+
+    @Test
+    public void getUnitNormalVector_givenPlane_returnsCorrectUnitNormal() {
+        Double3D point = new Double3D(1, 2, 3);
+        Vector normalVector = new Vector(1, 0, 0);
+        Plane plane = new Plane(point, normalVector);
+        assertEquals(normalVector, plane.getUnitNormalVector());
+    }
+
+    @Test
     public void getVectorMagnitude_givenVector_returnsCorrectMagnitude() {
         double magnitude = Vector.getVectorMagnitude(new Vector(1, 2, 2));
         assertEquals(3, magnitude, EPSILON);

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -1629,4 +1629,17 @@ public class PottsLocationTest {
         assertEquals(locVoxels, loc.voxels);
         assertEquals(splitVoxels, split.voxels);
     }
+
+    @Test
+    public void split_withPlaneNoSelectionProbability_callsSplitWithDefaultSelectionProbability() {
+        Plane mockPlane = mock(Plane.class);
+        when(mockPlane.getReferencePoint()).thenReturn(new Double3D(0, 0, 0));
+        PottsLocationMock loc = new PottsLocationMock(voxelListAB);
+        PottsLocationMock spyLocation = spy(loc);
+        spyLocation.split(randomDoubleZero, mockPlane);
+        verify(spyLocation).split(
+                randomDoubleZero,
+                mockPlane,
+                .5);
+    }
 }

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -1637,9 +1637,6 @@ public class PottsLocationTest {
         PottsLocationMock loc = new PottsLocationMock(voxelListAB);
         PottsLocationMock spyLocation = spy(loc);
         spyLocation.split(randomDoubleZero, mockPlane);
-        verify(spyLocation).split(
-                randomDoubleZero,
-                mockPlane,
-                .5);
+        verify(spyLocation).split(randomDoubleZero, mockPlane, .5);
     }
 }


### PR DESCRIPTION
**Estimated time to review:** Small

**Summary of changes:**
- Added getters and tests for Plane attributes
- Added overloaded split function to PottsLocation that takes random and a plane as parameters and uses default split probability and test

**Justification of changes:**
- The neuroblast cell type will split the parent cell voxels into two daughter locations and then use attributes of those locations to determine which location will remain stem (be assigned to the parent cell) vs differentiating (be assigned to the daughter cell).
- The split selection probability should be set when the parent cell knows which of the two locations will be daughter vs self, but for the neuroblasts they will not know until it calls one of several functions that compare the two locations, which have to happen after the split.
- The default probability is .5, meaning the locations are returned randomly.

My other design option was to call the split function that takes a plane and a probability and calling it with any probability value, but I felt explicitly setting the probability suggests that the probability value matters (when here I could set the probability value to anything, I will be comparing the two resulting locations after split returns).