### PR TITLE
Make sizeTarget in PottsModuleProliferationSimple a parameter

### DIFF
--- a/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
+++ b/src/arcade/potts/agent/module/PottsModuleProliferationSimple.java
@@ -18,7 +18,7 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
     static final double SIZE_CHECKPOINT = 0.95;
 
     /** Target ratio of critical volume for division size checkpoint. */
-    static final double SIZE_TARGET = 2;
+    final double sizeTarget;
 
     /** Event rate for G1 phase (steps/tick). */
     final double rateG1;
@@ -65,6 +65,7 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         super(cell);
 
         Parameters parameters = cell.getParameters();
+        sizeTarget = parameters.getDouble("proliferation/SIZE_TARGET");
         rateG1 = parameters.getDouble("proliferation/RATE_G1");
         rateS = parameters.getDouble("proliferation/RATE_S");
         rateG2 = parameters.getDouble("proliferation/RATE_G2");
@@ -96,12 +97,12 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         }
 
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
+        cell.updateTarget(cellGrowthRate, sizeTarget);
 
         // Increase size of nucleus (if cell has regions).
         if (cell.hasRegions()
                 && cell.getVolume(Region.NUCLEUS) > cell.getCriticalVolume(Region.NUCLEUS)) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, sizeTarget);
         }
 
         // Check for phase transition.
@@ -122,11 +123,11 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
     @Override
     void stepS(MersenneTwisterFast random) {
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
+        cell.updateTarget(cellGrowthRate, sizeTarget);
 
         // Increase size of nucleus (if cell has regions).
         if (cell.hasRegions()) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, sizeTarget);
         }
 
         // Check for phase transition.
@@ -154,18 +155,18 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
         }
 
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
+        cell.updateTarget(cellGrowthRate, sizeTarget);
         boolean sizeCheck =
-                cell.getVolume() >= SIZE_CHECKPOINT * SIZE_TARGET * cell.getCriticalVolume();
+                cell.getVolume() >= SIZE_CHECKPOINT * sizeTarget * cell.getCriticalVolume();
 
         // Increase size of nucleus (if cell has regions).
         boolean sizeRegionCheck = true;
         if (cell.hasRegions()) {
-            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, SIZE_TARGET);
+            cell.updateTarget(Region.NUCLEUS, nucleusGrowthRate, sizeTarget);
             sizeRegionCheck =
                     cell.getVolume(Region.NUCLEUS)
                             >= SIZE_CHECKPOINT
-                                    * SIZE_TARGET
+                                    * sizeTarget
                                     * cell.getCriticalVolume(Region.NUCLEUS);
         }
 
@@ -188,7 +189,7 @@ public class PottsModuleProliferationSimple extends PottsModuleProliferation {
     @Override
     void stepM(MersenneTwisterFast random, Simulation sim) {
         // Increase size of cell.
-        cell.updateTarget(cellGrowthRate, SIZE_TARGET);
+        cell.updateTarget(cellGrowthRate, sizeTarget);
 
         // Update size of nucleus (if cell has regions).
         if (cell.hasRegions()) {

--- a/src/arcade/potts/parameter.potts.xml
+++ b/src/arcade/potts/parameter.potts.xml
@@ -50,6 +50,7 @@
     <population id="CRITICAL_HEIGHT_NUCLEUS" value="TRUNCATED_NORMAL(MU=6.5,SIGMA=1.5)" units="um" conversion="DS^-1" />
 
     <!-- proliferation module parameters -->
+    <population.module module="proliferation" id="SIZE_TARGET" value="2" description="target ratio of critical volume cell must reach before dividing" />
     <population.module module="proliferation" id="RATE_G1" value="8.33" units="steps/hour" conversion="DT" description="rate of events in proliferative G1 phase" />
     <population.module module="proliferation" id="RATE_S" value="4.35" units="steps/hour" conversion="DT" description="rate of events in proliferative S phase" />
     <population.module module="proliferation" id="RATE_G2" value="0.752" units="steps/hour" conversion="DT" description="rate of events in proliferative G2 phase" />


### PR DESCRIPTION
**Estimated time to review:** Small

**Summary of changes:**
- Made sizeTarget a parameter with default value 2
- Save sizeTarget from parameters object in PottsModuleProliferation constructor
- Adjusted PottsModuleProliferation tests to test for dynamic setting of sizeTarget