### PR TITLE
Add swapVoxels function to PottsLocation

### DIFF
--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -10,6 +10,8 @@ import arcade.core.env.location.Location;
 import arcade.core.env.location.LocationContainer;
 import arcade.core.util.Plane;
 import arcade.core.util.Utilities;
+import arcade.potts.util.PottsEnums.Direction;
+import arcade.potts.util.PottsEnums.Region;
 import static arcade.potts.util.PottsEnums.Direction;
 import static arcade.potts.util.PottsEnums.Region;
 
@@ -657,6 +659,19 @@ public abstract class PottsLocation implements Location {
         height = calculateHeight();
         calculateCenter();
         return makeLocation(voxelsB);
+    }
+
+    /**
+     * Swaps the voxels in this location with the voxels in another location.
+     *
+     * @param location the location to swap with
+     */
+    public void swapVoxels(PottsLocation location) {
+        ArrayList<Voxel> initVoxels = new ArrayList<>(voxels);
+        voxels.clear();
+        voxels.addAll(location.voxels);
+        location.voxels.clear();
+        location.voxels.addAll(initVoxels);
     }
 
     /**

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -71,6 +71,16 @@ public abstract class PottsLocation implements Location {
      */
     public PottsLocation(ArrayList<Voxel> voxels) {
         this.voxels = new ArrayList<>(voxels);
+        setAttributes();
+    }
+
+    /**
+     * Sets the {@code PottsLocation} attributes.
+     *
+     * @param id the location id
+     * @param voxels the list of voxels
+     */
+    private void setAttributes() {
         this.volume = voxels.size();
         this.surface = calculateSurface();
         this.height = calculateHeight();
@@ -667,20 +677,14 @@ public abstract class PottsLocation implements Location {
      * @param location2 the other location to swap
      */
     public static void swapVoxels(PottsLocation location1, PottsLocation location2) {
-        ArrayList<Voxel> loc1InitVoxels = new ArrayList<Voxel>();
-        loc1InitVoxels.addAll(location1.voxels);
+        ArrayList<Voxel> tempVoxelList = new ArrayList<Voxel>();
+        tempVoxelList.addAll(location1.voxels);
         location1.voxels.clear();
         location1.voxels.addAll(location2.voxels);
         location2.voxels.clear();
-        location2.voxels.addAll(loc1InitVoxels);
-        location1.volume = location1.voxels.size();
-        location1.surface = location1.calculateSurface();
-        location1.height = location1.calculateHeight();
-        location1.calculateCenter();
-        location2.volume = location2.voxels.size();
-        location2.surface = location2.calculateSurface();
-        location2.height = location2.calculateHeight();
-        location2.calculateCenter();
+        location2.voxels.addAll(tempVoxelList);
+        location1.setAttributes();
+        location2.setAttributes();
     }
 
     /**

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -660,7 +660,8 @@ public abstract class PottsLocation implements Location {
     }
 
     /**
-     * Swaps the voxels in two locations and updates location attributes.
+     * Swaps the voxels in two locations and updates each location's size, surface, height, and
+     * center attributes.
      *
      * @param location1 one location to swap
      * @param location2 the other location to swap

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -10,8 +10,6 @@ import arcade.core.env.location.Location;
 import arcade.core.env.location.LocationContainer;
 import arcade.core.util.Plane;
 import arcade.core.util.Utilities;
-import arcade.potts.util.PottsEnums.Direction;
-import arcade.potts.util.PottsEnums.Region;
 import static arcade.potts.util.PottsEnums.Direction;
 import static arcade.potts.util.PottsEnums.Region;
 

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -666,7 +666,8 @@ public abstract class PottsLocation implements Location {
      * @param location2 the other location to swap
      */
     public static void swapVoxels(PottsLocation location1, PottsLocation location2) {
-        ArrayList<Voxel> loc1InitVoxels = location1.voxels;
+        ArrayList<Voxel> loc1InitVoxels = new ArrayList<Voxel>();
+        loc1InitVoxels.addAll(location1.voxels);
         location1.voxels.clear();
         location1.voxels.addAll(location2.voxels);
         location2.voxels.clear();

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -660,7 +660,7 @@ public abstract class PottsLocation implements Location {
     }
 
     /**
-     * Swaps the voxels in two locations.
+     * Swaps the voxels in two locations and updates location attributes.
      *
      * @param location1 one location to swap
      * @param location2 the other location to swap

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -75,7 +75,7 @@ public abstract class PottsLocation implements Location {
     }
 
     /** Sets the {@code PottsLocation} attributes. */
-    private void setAttributes() {
+    public void setAttributes() {
         this.volume = voxels.size();
         this.surface = calculateSurface();
         this.height = calculateHeight();

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -660,16 +660,17 @@ public abstract class PottsLocation implements Location {
     }
 
     /**
-     * Swaps the voxels in this location with the voxels in another location.
+     * Swaps the voxels in two locations.
      *
-     * @param location the location to swap with
+     * @param location1 one location to swap
+     * @param location2 the other location to swap
      */
-    public void swapVoxels(PottsLocation location) {
-        ArrayList<Voxel> initVoxels = new ArrayList<>(voxels);
-        voxels.clear();
-        voxels.addAll(location.voxels);
-        location.voxels.clear();
-        location.voxels.addAll(initVoxels);
+    public static void swapVoxels(PottsLocation location1, PottsLocation location2) {
+        ArrayList<Voxel> loc1InitVoxels = location1.voxels;
+        location1.voxels.clear();
+        location1.voxels.addAll(location2.voxels);
+        location2.voxels.clear();
+        location2.voxels.addAll(loc1InitVoxels);
     }
 
     /**

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -10,6 +10,8 @@ import arcade.core.env.location.Location;
 import arcade.core.env.location.LocationContainer;
 import arcade.core.util.Plane;
 import arcade.core.util.Utilities;
+import arcade.potts.util.PottsEnums.Direction;
+import arcade.potts.util.PottsEnums.Region;
 import static arcade.potts.util.PottsEnums.Direction;
 import static arcade.potts.util.PottsEnums.Region;
 
@@ -672,6 +674,14 @@ public abstract class PottsLocation implements Location {
         location1.voxels.addAll(location2.voxels);
         location2.voxels.clear();
         location2.voxels.addAll(loc1InitVoxels);
+        location1.volume = location1.voxels.size();
+        location1.surface = location1.calculateSurface();
+        location1.height = location1.calculateHeight();
+        location1.calculateCenter();
+        location2.volume = location2.voxels.size();
+        location2.surface = location2.calculateSurface();
+        location2.height = location2.calculateHeight();
+        location2.calculateCenter();
     }
 
     /**

--- a/src/arcade/potts/env/location/PottsLocation.java
+++ b/src/arcade/potts/env/location/PottsLocation.java
@@ -74,12 +74,7 @@ public abstract class PottsLocation implements Location {
         setAttributes();
     }
 
-    /**
-     * Sets the {@code PottsLocation} attributes.
-     *
-     * @param id the location id
-     * @param voxels the list of voxels
-     */
+    /** Sets the {@code PottsLocation} attributes. */
     private void setAttributes() {
         this.volume = voxels.size();
         this.surface = calculateSurface();

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -9,6 +9,8 @@ import sim.util.Double3D;
 import ec.util.MersenneTwisterFast;
 import arcade.core.util.Plane;
 import arcade.core.util.Vector;
+import arcade.potts.util.PottsEnums.Direction;
+import arcade.potts.util.PottsEnums.Region;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
@@ -1401,14 +1403,10 @@ public class PottsLocationTest {
         assertEquals(voxelListA, locB.voxels);
 
         assertEquals(locA.volume, voxelListB.size());
-        verify(locA).calculateSurface();
-        verify(locA).calculateHeight();
-        verify(locA).calculateCenter();
+        verify(locA).setAttributes();
 
         assertEquals(locB.volume, voxelListA.size());
-        verify(locB).calculateSurface();
-        verify(locB).calculateHeight();
-        verify(locB).calculateCenter();
+        verify(locB).setAttributes();
     }
 
     @Test

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -1394,7 +1394,7 @@ public class PottsLocationTest {
     void swapVoxels_validLists_swapsVoxels() {
         PottsLocationMock locA = new PottsLocationMock(voxelListA);
         PottsLocationMock locB = new PottsLocationMock(voxelListB);
-        locA.swapVoxels(locB);
+        PottsLocation.swapVoxels(locA, locB);
         assertEquals(voxelListB, locA.voxels);
         assertEquals(voxelListA, locB.voxels);
     }

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -9,8 +9,6 @@ import sim.util.Double3D;
 import ec.util.MersenneTwisterFast;
 import arcade.core.util.Plane;
 import arcade.core.util.Vector;
-import arcade.potts.util.PottsEnums.Direction;
-import arcade.potts.util.PottsEnums.Region;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -9,6 +9,8 @@ import sim.util.Double3D;
 import ec.util.MersenneTwisterFast;
 import arcade.core.util.Plane;
 import arcade.core.util.Vector;
+import arcade.potts.util.PottsEnums.Direction;
+import arcade.potts.util.PottsEnums.Region;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
@@ -1391,12 +1393,24 @@ public class PottsLocationTest {
     }
 
     @Test
-    void swapVoxels_validLists_swapsVoxels() {
-        PottsLocationMock locA = new PottsLocationMock(voxelListA);
-        PottsLocationMock locB = new PottsLocationMock(voxelListB);
+    void swapVoxels_validLists_swapsVoxelsCallsUpdateMethodsOnBothLocations() {
+        PottsLocationMock locA = spy(new PottsLocationMock(voxelListA));
+        PottsLocationMock locB = spy(new PottsLocationMock(voxelListB));
+
         PottsLocation.swapVoxels(locA, locB);
+
         assertEquals(voxelListB, locA.voxels);
         assertEquals(voxelListA, locB.voxels);
+
+        assertEquals(locA.volume, voxelListB.size());
+        verify(locA).calculateSurface();
+        verify(locA).calculateHeight();
+        verify(locA).calculateCenter();
+
+        assertEquals(locB.volume, voxelListA.size());
+        verify(locB).calculateSurface();
+        verify(locB).calculateHeight();
+        verify(locB).calculateCenter();
     }
 
     @Test

--- a/test/arcade/potts/env/location/PottsLocationTest.java
+++ b/test/arcade/potts/env/location/PottsLocationTest.java
@@ -9,6 +9,8 @@ import sim.util.Double3D;
 import ec.util.MersenneTwisterFast;
 import arcade.core.util.Plane;
 import arcade.core.util.Vector;
+import arcade.potts.util.PottsEnums.Direction;
+import arcade.potts.util.PottsEnums.Region;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static arcade.core.ARCADETestUtilities.*;
@@ -1388,6 +1390,15 @@ public class PottsLocationTest {
         assertEquals(8. / 3, split.cx, EPSILON);
         assertEquals(1. / 3, split.cy, EPSILON);
         assertEquals(3. / 3, split.cz, EPSILON);
+    }
+
+    @Test
+    void swapVoxels_validLists_swapsVoxels() {
+        PottsLocationMock locA = new PottsLocationMock(voxelListA);
+        PottsLocationMock locB = new PottsLocationMock(voxelListB);
+        locA.swapVoxels(locB);
+        assertEquals(voxelListB, locA.voxels);
+        assertEquals(voxelListA, locB.voxels);
     }
 
     @Test


### PR DESCRIPTION
**Estimated time to review:** Small

**Summary of changes:**
- added swapVoxels function to PottsLocation that swaps the voxels of two location
- added one test to PottsLocationTest

**Justification of changes:**
The function that splits a cell's location into two daughter cells automatically assigns one daughter cell location to one cell and one to another. There are times when the neuroblast will need to swap which location belongs to which cell. This function is my proposed solution.