### PR TITLE
Add graph logging with bonus command settings changes

### DIFF
--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -30,33 +30,23 @@ import arcade.potts.PottsARCADE;
 /**
  * Entry point class for ARCADE simulations.
  *
- * <p>
- * The class loads two XML files {@code command.xml} and {@code parameter.xml}
- * that specify the
- * command line parser options and the default parameter values, respectively.
- * The setup XML file is
- * then parsed to produce an array of {@link Series} objects, each of which
- * defines replicates
- * (differing only in random seed) of {@link arcade.core.sim.Simulation}
- * instances to run.
+ * <p>The class loads two XML files {@code command.xml} and {@code parameter.xml} that specify the
+ * command line parser options and the default parameter values, respectively. The setup XML file is
+ * then parsed to produce an array of {@link Series} objects, each of which defines replicates
+ * (differing only in random seed) of {@link arcade.core.sim.Simulation} instances to run.
  *
- * <p>
- * If the visualization flag is used, only the first valid {@link Series} in the
- * array is run.
+ * <p>If the visualization flag is used, only the first valid {@link Series} in the array is run.
  * Otherwise, all valid {@code Series} are run.
  *
- * <p>
- * An implementing package {@code <implementation>} extends this class to define
- * implementation
+ * <p>An implementing package {@code <implementation>} extends this class to define implementation
  * specific:
  *
  * <ul>
- * <li>{@code command.<implementation>.xml} with custom command line parameters
- * <li>{@code parameter.<implementation>.xml} with new default parameter values
- * <li>{@link InputBuilder} for building implementation series from the setup
- * XML
- * <li>{@link OutputLoader} for loading classes
- * <li>{@link OutputSaver} for saving classes
+ *   <li>{@code command.<implementation>.xml} with custom command line parameters
+ *   <li>{@code parameter.<implementation>.xml} with new default parameter values
+ *   <li>{@link InputBuilder} for building implementation series from the setup XML
+ *   <li>{@link OutputLoader} for loading classes
+ *   <li>{@link OutputSaver} for saving classes
  * </ul>
  */
 public abstract class ARCADE {
@@ -164,9 +154,7 @@ public abstract class ARCADE {
     /**
      * Gets full version number.
      *
-     * <p>
-     * If running with a jar, the version is pulled from the jar manifest.
-     * Otherwise, the version
+     * <p>If running with a jar, the version is pulled from the jar manifest. Otherwise, the version
      * is extracted using git.
      *
      * @return the version number
@@ -177,8 +165,9 @@ public abstract class ARCADE {
 
         try {
             if (classPath.startsWith("jar")) {
-                String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1)
-                        + "/META-INF/MANIFEST.MF";
+                String manifestPath =
+                        classPath.substring(0, classPath.lastIndexOf("!") + 1)
+                                + "/META-INF/MANIFEST.MF";
                 Manifest manifest = new Manifest(new URL(manifestPath).openStream());
                 Attributes attr = manifest.getMainAttributes();
                 return attr.getValue("Implementation-Version");
@@ -263,7 +252,7 @@ public abstract class ARCADE {
     /**
      * Parses arguments using command line parser.
      *
-     * @param args     the list of arguments
+     * @param args the list of arguments
      * @param commands the command line parser settings
      * @return the container of parsed arguments
      */
@@ -296,9 +285,7 @@ public abstract class ARCADE {
     /**
      * Runs simulations for each {@link Series}.
      *
-     * <p>
-     * If the {@code --vis} flag is set, then only the first valid series is run.
-     * Otherwise, all
+     * <p>If the {@code --vis} flag is set, then only the first valid series is run. Otherwise, all
      * valid series in the list are run.
      *
      * @param series the list of {@link Series} instances

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -56,6 +56,9 @@ public abstract class ARCADE {
     /** Version number. */
     public static final String VERSION = loadVersion();
 
+    /** Command line settings for ARCADE simulation */
+    protected MiniBox settings;
+
     /**
      * Gets the resource relative to the location of the class.
      *
@@ -139,13 +142,13 @@ public abstract class ARCADE {
         Box parameters = arcade.loadParameters(args[0]);
 
         // Parse arguments from command line.
-        MiniBox settings = arcade.parseArguments(args, commands);
+        arcade.settings = arcade.parseArguments(args, commands);
 
         // Build series
-        ArrayList<Series> series = arcade.buildSeries(parameters, settings);
+        ArrayList<Series> series = arcade.buildSeries(parameters);
 
         // Run series.
-        arcade.runSeries(series, settings);
+        arcade.runSeries(series);
     }
 
     /**
@@ -267,8 +270,7 @@ public abstract class ARCADE {
      * @param settings a container of parsed arguments
      * @return a list of {@link Series} instances
      */
-    ArrayList<Series> buildSeries(Box parameters, MiniBox settings)
-            throws IOException, SAXException {
+    ArrayList<Series> buildSeries(Box parameters) throws IOException, SAXException {
         String setupFile = settings.get("SETUP_FILE");
         String snapshotPath = settings.get("SNAPSHOT_PATH");
         boolean isVis = settings.contains("VIS");
@@ -290,7 +292,7 @@ public abstract class ARCADE {
      * @param series the list of {@link Series} instances
      * @param settings a container of parsed arguments
      */
-    void runSeries(ArrayList<Series> series, MiniBox settings) throws Exception {
+    void runSeries(ArrayList<Series> series) throws Exception {
         boolean isVis = settings.contains("VIS");
         String loadPath = settings.get("LOAD_PATH");
         boolean loadCells = settings.contains("LOAD_CELLS");

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -57,7 +57,7 @@ public abstract class ARCADE {
     public static final String VERSION = loadVersion();
 
     /** Command line settings for ARCADE simulation. */
-    protected MiniBox settings;
+    protected MiniBox settings = new MiniBox();
 
     /**
      * Gets the resource relative to the location of the class.

--- a/src/arcade/core/ARCADE.java
+++ b/src/arcade/core/ARCADE.java
@@ -30,23 +30,33 @@ import arcade.potts.PottsARCADE;
 /**
  * Entry point class for ARCADE simulations.
  *
- * <p>The class loads two XML files {@code command.xml} and {@code parameter.xml} that specify the
- * command line parser options and the default parameter values, respectively. The setup XML file is
- * then parsed to produce an array of {@link Series} objects, each of which defines replicates
- * (differing only in random seed) of {@link arcade.core.sim.Simulation} instances to run.
+ * <p>
+ * The class loads two XML files {@code command.xml} and {@code parameter.xml}
+ * that specify the
+ * command line parser options and the default parameter values, respectively.
+ * The setup XML file is
+ * then parsed to produce an array of {@link Series} objects, each of which
+ * defines replicates
+ * (differing only in random seed) of {@link arcade.core.sim.Simulation}
+ * instances to run.
  *
- * <p>If the visualization flag is used, only the first valid {@link Series} in the array is run.
+ * <p>
+ * If the visualization flag is used, only the first valid {@link Series} in the
+ * array is run.
  * Otherwise, all valid {@code Series} are run.
  *
- * <p>An implementing package {@code <implementation>} extends this class to define implementation
+ * <p>
+ * An implementing package {@code <implementation>} extends this class to define
+ * implementation
  * specific:
  *
  * <ul>
- *   <li>{@code command.<implementation>.xml} with custom command line parameters
- *   <li>{@code parameter.<implementation>.xml} with new default parameter values
- *   <li>{@link InputBuilder} for building implementation series from the setup XML
- *   <li>{@link OutputLoader} for loading classes
- *   <li>{@link OutputSaver} for saving classes
+ * <li>{@code command.<implementation>.xml} with custom command line parameters
+ * <li>{@code parameter.<implementation>.xml} with new default parameter values
+ * <li>{@link InputBuilder} for building implementation series from the setup
+ * XML
+ * <li>{@link OutputLoader} for loading classes
+ * <li>{@link OutputSaver} for saving classes
  * </ul>
  */
 public abstract class ARCADE {
@@ -56,7 +66,7 @@ public abstract class ARCADE {
     /** Version number. */
     public static final String VERSION = loadVersion();
 
-    /** Command line settings for ARCADE simulation */
+    /** Command line settings for ARCADE simulation. */
     protected MiniBox settings;
 
     /**
@@ -154,7 +164,9 @@ public abstract class ARCADE {
     /**
      * Gets full version number.
      *
-     * <p>If running with a jar, the version is pulled from the jar manifest. Otherwise, the version
+     * <p>
+     * If running with a jar, the version is pulled from the jar manifest.
+     * Otherwise, the version
      * is extracted using git.
      *
      * @return the version number
@@ -165,9 +177,8 @@ public abstract class ARCADE {
 
         try {
             if (classPath.startsWith("jar")) {
-                String manifestPath =
-                        classPath.substring(0, classPath.lastIndexOf("!") + 1)
-                                + "/META-INF/MANIFEST.MF";
+                String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1)
+                        + "/META-INF/MANIFEST.MF";
                 Manifest manifest = new Manifest(new URL(manifestPath).openStream());
                 Attributes attr = manifest.getMainAttributes();
                 return attr.getValue("Implementation-Version");
@@ -252,7 +263,7 @@ public abstract class ARCADE {
     /**
      * Parses arguments using command line parser.
      *
-     * @param args the list of arguments
+     * @param args     the list of arguments
      * @param commands the command line parser settings
      * @return the container of parsed arguments
      */
@@ -267,7 +278,6 @@ public abstract class ARCADE {
      * Builds series based on setup file.
      *
      * @param parameters a container of default parameter values
-     * @param settings a container of parsed arguments
      * @return a list of {@link Series} instances
      */
     ArrayList<Series> buildSeries(Box parameters) throws IOException, SAXException {
@@ -286,11 +296,12 @@ public abstract class ARCADE {
     /**
      * Runs simulations for each {@link Series}.
      *
-     * <p>If the {@code --vis} flag is set, then only the first valid series is run. Otherwise, all
+     * <p>
+     * If the {@code --vis} flag is set, then only the first valid series is run.
+     * Otherwise, all
      * valid series in the list are run.
      *
      * @param series the list of {@link Series} instances
-     * @param settings a container of parsed arguments
      */
     void runSeries(ArrayList<Series> series) throws Exception {
         boolean isVis = settings.contains("VIS");

--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -113,7 +113,7 @@ public abstract class OutputSaver implements Steppable {
     }
 
     /**
-     * Saves the relevant data
+     * Saves the relevant data.
      *
      * @param tick the simulation tick
      */

--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -109,6 +109,15 @@ public abstract class OutputSaver implements Steppable {
     @Override
     public void step(SimState simstate) {
         int tick = (int) simstate.schedule.getTime();
+        save(tick);
+    }
+
+    /**
+     * Saves the relevant data
+     *
+     * @param tick the simulation tick
+     */
+    public void save(int tick) {
         saveCells(tick);
         saveLocations(tick);
     }

--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -31,10 +31,10 @@ public abstract class OutputSaver implements Steppable {
     protected static final Logger LOGGER = Logger.getLogger(OutputSaver.class.getName());
 
     /** Number of elements to format in output string. */
-    private static final int FORMAT_ELEMENTS = 6;
+    protected static final int FORMAT_ELEMENTS = 6;
 
     /** JSON representation. */
-    final Gson gson;
+    protected final Gson gson;
 
     /** {@link arcade.core.sim.Series} instance. */
     final Series series;
@@ -43,7 +43,7 @@ public abstract class OutputSaver implements Steppable {
     public String prefix;
 
     /** {@link arcade.core.sim.Simulation} instance. */
-    Simulation sim;
+    protected Simulation sim;
 
     /**
      * Creates an {@code OutputSaver} for the series.

--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -28,7 +28,7 @@ import static arcade.core.sim.Simulation.DEFAULT_LOCATION_TYPE;
  */
 public abstract class OutputSaver implements Steppable {
     /** Logger for {@code OutputSaver}. */
-    private static final Logger LOGGER = Logger.getLogger(OutputSaver.class.getName());
+    protected static final Logger LOGGER = Logger.getLogger(OutputSaver.class.getName());
 
     /** Number of elements to format in output string. */
     private static final int FORMAT_ELEMENTS = 6;

--- a/src/arcade/patch/PatchARCADE.java
+++ b/src/arcade/patch/PatchARCADE.java
@@ -32,9 +32,7 @@ public final class PatchARCADE extends ARCADE {
     @Override
     public OutputSaver getSaver(Series series) {
         PatchOutputSaver saver = new PatchOutputSaver(series);
-        if (settings != null) {
-            saver.saveGraph = settings.contains("SAVE_GRAPH");
-        }
+        saver.saveGraph = settings.contains("SAVE_GRAPH");
         return saver;
     }
 }

--- a/src/arcade/patch/PatchARCADE.java
+++ b/src/arcade/patch/PatchARCADE.java
@@ -31,6 +31,10 @@ public final class PatchARCADE extends ARCADE {
 
     @Override
     public OutputSaver getSaver(Series series) {
-        return new PatchOutputSaver(series);
+        PatchOutputSaver saver = new PatchOutputSaver(series);
+        if (settings != null) {
+            saver.saveGraph = settings.contains("SAVE_GRAPH");
+        }
+        return saver;
     }
 }

--- a/src/arcade/patch/command.patch.xml
+++ b/src/arcade/patch/command.patch.xml
@@ -1,2 +1,4 @@
 <commands>
+    <switch id="SAVE_GRAPH" short="g" long="graph" help="Save the GRAPH output files" />
+    <switch id="SAVE_NUTRIENTS" short="n" long="nutrients" help="Save the NUTRIENT output files" />
 </commands>

--- a/src/arcade/patch/command.patch.xml
+++ b/src/arcade/patch/command.patch.xml
@@ -1,4 +1,3 @@
 <commands>
     <switch id="SAVE_GRAPH" short="g" long="graph" help="Save the GRAPH output files" />
-    <switch id="SAVE_NUTRIENTS" short="n" long="nutrients" help="Save the NUTRIENT output files" />
 </commands>

--- a/src/arcade/patch/env/component/PatchComponentSitesGraph.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraph.java
@@ -23,24 +23,36 @@ import static arcade.patch.env.component.PatchComponentSitesGraphUtilities.*;
 /**
  * Extension of {@link PatchComponentSites} for graph sites.
  *
- * <p>Layout of the underlying graph is specified by {@code GRAPH_LAYOUT}. The pattern layout is
- * specified by using {@code "*"}. The root layout is specified by specifying roots:
+ * <p>
+ * Layout of the underlying graph is specified by {@code GRAPH_LAYOUT}. The
+ * pattern layout is
+ * specified by using {@code "*"}. The root layout is specified by specifying
+ * roots:
  *
  * <ul>
- *   <li>{@code [<BORDER> random <#>]} = random roots with {@code <#>} randomly spaced roots,
- *       randomly assigned as artery or vein
- *   <li>{@code [<BORDER> alternate <#>]} = alternating roots with {@code <#>} evenly spaced roots,
- *       alternating between arteries and veins
- *   <li>{@code [<BORDER> single <#><TYPE>]} = single {@code <TYPE>} root placed a distance {@code
+ * <li>{@code [<BORDER> random <#>]} = random roots with {@code <#>} randomly
+ * spaced roots,
+ * randomly assigned as artery or vein
+ * <li>{@code [<BORDER> alternate <#>]} = alternating roots with {@code <#>}
+ * evenly spaced roots,
+ * alternating between arteries and veins
+ * <li>{@code [<BORDER> single <#><TYPE>]} = single {@code <TYPE>} root placed a
+ * distance {@code
  *       <#>} percent across the specified border
- *   <li>{@code [<BORDER> line <#><TYPE><#>]} = line {@code <TYPE>} root placed a distance {@code
- *       <#>} (first number) percent across the specified border that spans a distance {@code <#>}
- *       (second number) percent across the environment in the direction normal to the specified
- *       border
+ * <li>{@code [<BORDER> line <#><TYPE><#>]} = line {@code <TYPE>} root placed a
+ * distance {@code
+ *       <#>} (first number) percent across the specified border that spans a
+ * distance {@code <#>}
+ * (second number) percent across the environment in the direction normal to the
+ * specified
+ * border
  * </ul>
  *
- * <p>The border {@code <BORDER>} can be {@code LEFT} (-x direction), {@code RIGHT} (+x direction),
- * {@code TOP} (-y direction), or {@code BOTTOM} (+y direction). The type {@code <TYPE>} can be
+ * <p>
+ * The border {@code <BORDER>} can be {@code LEFT} (-x direction), {@code RIGHT}
+ * (+x direction),
+ * {@code TOP} (-y direction), or {@code BOTTOM} (+y direction). The type
+ * {@code <TYPE>} can be
  * {@code A} / {@code a} for an artery or {@code V} / {@code v} for a vein.
  */
 public abstract class PatchComponentSitesGraph extends PatchComponentSites {
@@ -77,17 +89,18 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Creates a {@link PatchComponentSites} using graph sites.
      *
-     * <p>Loaded parameters include:
+     * <p>
+     * Loaded parameters include:
      *
      * <ul>
-     *   <li>{@code GRAPH_LAYOUT} = graph layout type
-     *   <li>{@code OXYGEN_SOLUBILITY_PLASMA} = solubility of oxygen in plasma
-     *   <li>{@code OXYGEN_SOLUBILITY_TISSUE} = solubility of oxygen in tissue
+     * <li>{@code GRAPH_LAYOUT} = graph layout type
+     * <li>{@code OXYGEN_SOLUBILITY_PLASMA} = solubility of oxygen in plasma
+     * <li>{@code OXYGEN_SOLUBILITY_TISSUE} = solubility of oxygen in tissue
      * </ul>
      *
-     * @param series the simulation series
+     * @param series     the simulation series
      * @param parameters the component parameters dictionary
-     * @param random the random number generator
+     * @param random     the random number generator
      */
     public PatchComponentSitesGraph(Series series, MiniBox parameters, MersenneTwisterFast random) {
         super(series);
@@ -127,7 +140,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
      * Gets the lattice coordinates spanned by an edge between two nodes.
      *
      * @param from the node the edge extends from
-     * @param to the node the edge extends to
+     * @param to   the node the edge extends to
      * @return the list of span coordinates
      */
     abstract ArrayList<CoordinateXYZ> getSpan(SiteNode from, SiteNode to);
@@ -157,8 +170,11 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Initializes graph for representing sites.
      *
-     * <p>Calls the correct method to populate the graph with edges (either pattern or root layout).
-     * After the graph is defined, the corresponding indices in the lattice adjacent to edges are
+     * <p>
+     * Calls the correct method to populate the graph with edges (either pattern or
+     * root layout).
+     * After the graph is defined, the corresponding indices in the lattice adjacent
+     * to edges are
      * marked.
      *
      * @param random the random number generator
@@ -190,10 +206,13 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Graph step that only considers differences in concentration.
      *
-     * <p>Method is equivalent to the step used with {@link
+     * <p>
+     * Method is equivalent to the step used with {@link
      * arcade.patch.env.component.PatchComponentSitesSource} and {@link
-     * arcade.patch.env.component.PatchComponentSitesPattern} where the amount of concentration
-     * added is the difference between the source concentration and the current concentration for a
+     * arcade.patch.env.component.PatchComponentSitesPattern} where the amount of
+     * concentration
+     * added is the difference between the source concentration and the current
+     * concentration for a
      * given molecule.
      */
     void simpleStep() {
@@ -233,8 +252,11 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Graph step that uses traversals to calculate exact hemodynamics.
      *
-     * <p>Traversing the graph updates the concentrations of molecules in each edge. The amount of
-     * concentration added is a function of flow rate and permeability to the given molecule.
+     * <p>
+     * Traversing the graph updates the concentrations of molecules in each edge.
+     * The amount of
+     * concentration added is a function of flow rate and permeability to the given
+     * molecule.
      *
      * @param random the random number generator
      */
@@ -335,9 +357,8 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
                     // Check for stability.
                     double max = latticePatchVolume / edge.area;
                     if (permeability > max) {
-                        intConcNew =
-                                (intConcNew * flow + latticePatchVolume * extConcNew)
-                                        / (flow + latticePatchVolume);
+                        intConcNew = (intConcNew * flow + latticePatchVolume * extConcNew)
+                                / (flow + latticePatchVolume);
                         extConcNew = intConcNew;
                     } else {
                         // Iterate for each second in the minute time step.
@@ -355,14 +376,12 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
                         int k = coordinate.z;
 
                         if (layer.name.equalsIgnoreCase("OXYGEN")) {
-                            delta[k][i][j] +=
-                                    Math.max(
-                                            (extConcNew / oxySoluTissue
-                                                    - (current[k][i][j] + delta[k][i][j])),
-                                            0);
+                            delta[k][i][j] += Math.max(
+                                    (extConcNew / oxySoluTissue
+                                            - (current[k][i][j] + delta[k][i][j])),
+                                    0);
                         } else {
-                            delta[k][i][j] +=
-                                    Math.max((extConcNew - (current[k][i][j] + delta[k][i][j])), 0);
+                            delta[k][i][j] += Math.max((extConcNew - (current[k][i][j] + delta[k][i][j])), 0);
                         }
                     }
 
@@ -380,7 +399,8 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Extension of {@link arcade.core.util.Graph.Node} for site nodes.
      *
-     * <p>Node tracks additional hemodynamic properties including pressure and oxygen.
+     * <p>
+     * Node tracks additional hemodynamic properties including pressure and oxygen.
      */
     public static class SiteNode extends Node {
         /** Node ID. */
@@ -436,12 +456,23 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         public double getPressure() {
             return pressure;
         }
+
+        /**
+         * Get the oxygen partial pressure of the node.
+         *
+         * @return the node oxygen partial pressure
+         */
+        public double getOxygen() {
+            return oxygen;
+        }
     }
 
     /**
      * Extension of {@link arcade.core.util.Graph.Edge} for site edges.
      *
-     * <p>Node tracks additional hemodynamic properties including radius, length, wall thickness,
+     * <p>
+     * Node tracks additional hemodynamic properties including radius, length, wall
+     * thickness,
      * shear stress, circumferential stress, and volumetric flow rate.
      */
     public static class SiteEdge extends Edge {
@@ -458,7 +489,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         boolean isIgnored;
 
         /** Edge type. */
-        final EdgeType type;
+        public final EdgeType type;
 
         /** Edge resolution level. */
         final EdgeLevel level;
@@ -470,22 +501,22 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         double radius;
 
         /** Vessel length [um]. */
-        double length;
+        public double length;
 
         /** Wall thickness [um]. */
         double wall;
 
         /** Shear stress in edge [mmHg]. */
-        double shear;
+        public double shear;
 
         /** Circumferential stress in edge [mmHg]. */
-        double circum;
+        public double circum;
 
         /** Volumetric flow rate in edge [um<sup>3</sup>/min]. */
-        double flow;
+        public double flow;
 
         /** Cross-sectional area of edge [um<sup>2</sup>]. */
-        double area;
+        public double area;
 
         /** Scaled shear stress. */
         double shearScaled;
@@ -499,9 +530,9 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         /**
          * Creates a {@link Edge} for graph sites.
          *
-         * @param from the node the edge is from
-         * @param to the node the edge is to
-         * @param type the edge type
+         * @param from  the node the edge is from
+         * @param to    the node the edge is to
+         * @param type  the edge type
          * @param level the graph resolution level
          */
         SiteEdge(Node from, Node to, EdgeType type, EdgeLevel level) {
@@ -743,9 +774,8 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         for (Object obj : in) {
             SiteEdge edge = (SiteEdge) obj;
             if (!edge.isIgnored) {
-                massIn +=
-                        edge.flow * getTotal(edge.getFrom().oxygen, oxySoluPlasma)
-                                - edge.transport.get(code);
+                massIn += edge.flow * getTotal(edge.getFrom().oxygen, oxySoluPlasma)
+                        - edge.transport.get(code);
             }
         }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesGraph.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraph.java
@@ -23,36 +23,24 @@ import static arcade.patch.env.component.PatchComponentSitesGraphUtilities.*;
 /**
  * Extension of {@link PatchComponentSites} for graph sites.
  *
- * <p>
- * Layout of the underlying graph is specified by {@code GRAPH_LAYOUT}. The
- * pattern layout is
- * specified by using {@code "*"}. The root layout is specified by specifying
- * roots:
+ * <p>Layout of the underlying graph is specified by {@code GRAPH_LAYOUT}. The pattern layout is
+ * specified by using {@code "*"}. The root layout is specified by specifying roots:
  *
  * <ul>
- * <li>{@code [<BORDER> random <#>]} = random roots with {@code <#>} randomly
- * spaced roots,
- * randomly assigned as artery or vein
- * <li>{@code [<BORDER> alternate <#>]} = alternating roots with {@code <#>}
- * evenly spaced roots,
- * alternating between arteries and veins
- * <li>{@code [<BORDER> single <#><TYPE>]} = single {@code <TYPE>} root placed a
- * distance {@code
+ *   <li>{@code [<BORDER> random <#>]} = random roots with {@code <#>} randomly spaced roots,
+ *       randomly assigned as artery or vein
+ *   <li>{@code [<BORDER> alternate <#>]} = alternating roots with {@code <#>} evenly spaced roots,
+ *       alternating between arteries and veins
+ *   <li>{@code [<BORDER> single <#><TYPE>]} = single {@code <TYPE>} root placed a distance {@code
  *       <#>} percent across the specified border
- * <li>{@code [<BORDER> line <#><TYPE><#>]} = line {@code <TYPE>} root placed a
- * distance {@code
- *       <#>} (first number) percent across the specified border that spans a
- * distance {@code <#>}
- * (second number) percent across the environment in the direction normal to the
- * specified
- * border
+ *   <li>{@code [<BORDER> line <#><TYPE><#>]} = line {@code <TYPE>} root placed a distance {@code
+ *       <#>} (first number) percent across the specified border that spans a distance {@code <#>}
+ *       (second number) percent across the environment in the direction normal to the specified
+ *       border
  * </ul>
  *
- * <p>
- * The border {@code <BORDER>} can be {@code LEFT} (-x direction), {@code RIGHT}
- * (+x direction),
- * {@code TOP} (-y direction), or {@code BOTTOM} (+y direction). The type
- * {@code <TYPE>} can be
+ * <p>The border {@code <BORDER>} can be {@code LEFT} (-x direction), {@code RIGHT} (+x direction),
+ * {@code TOP} (-y direction), or {@code BOTTOM} (+y direction). The type {@code <TYPE>} can be
  * {@code A} / {@code a} for an artery or {@code V} / {@code v} for a vein.
  */
 public abstract class PatchComponentSitesGraph extends PatchComponentSites {
@@ -89,18 +77,17 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Creates a {@link PatchComponentSites} using graph sites.
      *
-     * <p>
-     * Loaded parameters include:
+     * <p>Loaded parameters include:
      *
      * <ul>
-     * <li>{@code GRAPH_LAYOUT} = graph layout type
-     * <li>{@code OXYGEN_SOLUBILITY_PLASMA} = solubility of oxygen in plasma
-     * <li>{@code OXYGEN_SOLUBILITY_TISSUE} = solubility of oxygen in tissue
+     *   <li>{@code GRAPH_LAYOUT} = graph layout type
+     *   <li>{@code OXYGEN_SOLUBILITY_PLASMA} = solubility of oxygen in plasma
+     *   <li>{@code OXYGEN_SOLUBILITY_TISSUE} = solubility of oxygen in tissue
      * </ul>
      *
-     * @param series     the simulation series
+     * @param series the simulation series
      * @param parameters the component parameters dictionary
-     * @param random     the random number generator
+     * @param random the random number generator
      */
     public PatchComponentSitesGraph(Series series, MiniBox parameters, MersenneTwisterFast random) {
         super(series);
@@ -140,7 +127,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
      * Gets the lattice coordinates spanned by an edge between two nodes.
      *
      * @param from the node the edge extends from
-     * @param to   the node the edge extends to
+     * @param to the node the edge extends to
      * @return the list of span coordinates
      */
     abstract ArrayList<CoordinateXYZ> getSpan(SiteNode from, SiteNode to);
@@ -170,11 +157,8 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Initializes graph for representing sites.
      *
-     * <p>
-     * Calls the correct method to populate the graph with edges (either pattern or
-     * root layout).
-     * After the graph is defined, the corresponding indices in the lattice adjacent
-     * to edges are
+     * <p>Calls the correct method to populate the graph with edges (either pattern or root layout).
+     * After the graph is defined, the corresponding indices in the lattice adjacent to edges are
      * marked.
      *
      * @param random the random number generator
@@ -206,13 +190,10 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Graph step that only considers differences in concentration.
      *
-     * <p>
-     * Method is equivalent to the step used with {@link
+     * <p>Method is equivalent to the step used with {@link
      * arcade.patch.env.component.PatchComponentSitesSource} and {@link
-     * arcade.patch.env.component.PatchComponentSitesPattern} where the amount of
-     * concentration
-     * added is the difference between the source concentration and the current
-     * concentration for a
+     * arcade.patch.env.component.PatchComponentSitesPattern} where the amount of concentration
+     * added is the difference between the source concentration and the current concentration for a
      * given molecule.
      */
     void simpleStep() {
@@ -252,11 +233,8 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Graph step that uses traversals to calculate exact hemodynamics.
      *
-     * <p>
-     * Traversing the graph updates the concentrations of molecules in each edge.
-     * The amount of
-     * concentration added is a function of flow rate and permeability to the given
-     * molecule.
+     * <p>Traversing the graph updates the concentrations of molecules in each edge. The amount of
+     * concentration added is a function of flow rate and permeability to the given molecule.
      *
      * @param random the random number generator
      */
@@ -357,8 +335,9 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
                     // Check for stability.
                     double max = latticePatchVolume / edge.area;
                     if (permeability > max) {
-                        intConcNew = (intConcNew * flow + latticePatchVolume * extConcNew)
-                                / (flow + latticePatchVolume);
+                        intConcNew =
+                                (intConcNew * flow + latticePatchVolume * extConcNew)
+                                        / (flow + latticePatchVolume);
                         extConcNew = intConcNew;
                     } else {
                         // Iterate for each second in the minute time step.
@@ -376,12 +355,14 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
                         int k = coordinate.z;
 
                         if (layer.name.equalsIgnoreCase("OXYGEN")) {
-                            delta[k][i][j] += Math.max(
-                                    (extConcNew / oxySoluTissue
-                                            - (current[k][i][j] + delta[k][i][j])),
-                                    0);
+                            delta[k][i][j] +=
+                                    Math.max(
+                                            (extConcNew / oxySoluTissue
+                                                    - (current[k][i][j] + delta[k][i][j])),
+                                            0);
                         } else {
-                            delta[k][i][j] += Math.max((extConcNew - (current[k][i][j] + delta[k][i][j])), 0);
+                            delta[k][i][j] +=
+                                    Math.max((extConcNew - (current[k][i][j] + delta[k][i][j])), 0);
                         }
                     }
 
@@ -399,8 +380,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Extension of {@link arcade.core.util.Graph.Node} for site nodes.
      *
-     * <p>
-     * Node tracks additional hemodynamic properties including pressure and oxygen.
+     * <p>Node tracks additional hemodynamic properties including pressure and oxygen.
      */
     public static class SiteNode extends Node {
         /** Node ID. */
@@ -470,9 +450,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
     /**
      * Extension of {@link arcade.core.util.Graph.Edge} for site edges.
      *
-     * <p>
-     * Node tracks additional hemodynamic properties including radius, length, wall
-     * thickness,
+     * <p>Node tracks additional hemodynamic properties including radius, length, wall thickness,
      * shear stress, circumferential stress, and volumetric flow rate.
      */
     public static class SiteEdge extends Edge {
@@ -530,9 +508,9 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         /**
          * Creates a {@link Edge} for graph sites.
          *
-         * @param from  the node the edge is from
-         * @param to    the node the edge is to
-         * @param type  the edge type
+         * @param from the node the edge is from
+         * @param to the node the edge is to
+         * @param type the edge type
          * @param level the graph resolution level
          */
         SiteEdge(Node from, Node to, EdgeType type, EdgeLevel level) {
@@ -774,8 +752,9 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         for (Object obj : in) {
             SiteEdge edge = (SiteEdge) obj;
             if (!edge.isIgnored) {
-                massIn += edge.flow * getTotal(edge.getFrom().oxygen, oxySoluPlasma)
-                        - edge.transport.get(code);
+                massIn +=
+                        edge.flow * getTotal(edge.getFrom().oxygen, oxySoluPlasma)
+                                - edge.transport.get(code);
             }
         }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesGraph.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraph.java
@@ -467,7 +467,7 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         boolean isIgnored;
 
         /** Edge type. */
-        public final EdgeType type;
+        final EdgeType type;
 
         /** Edge resolution level. */
         final EdgeLevel level;
@@ -479,22 +479,22 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         double radius;
 
         /** Vessel length [um]. */
-        public double length;
+        double length;
 
         /** Wall thickness [um]. */
         double wall;
 
         /** Shear stress in edge [mmHg]. */
-        public double shear;
+        double shear;
 
         /** Circumferential stress in edge [mmHg]. */
-        public double circum;
+        double circum;
 
         /** Volumetric flow rate in edge [um<sup>3</sup>/min]. */
-        public double flow;
+        double flow;
 
         /** Cross-sectional area of edge [um<sup>2</sup>]. */
-        public double area;
+        double area;
 
         /** Scaled shear stress. */
         double shearScaled;
@@ -544,6 +544,15 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         }
 
         /**
+         * Gets the type of the edge.
+         *
+         * @return the edge type
+         */
+        public String getType() {
+            return type.toString();
+        }
+
+        /**
          * Get the radius of the edge.
          *
          * @return the edge radius
@@ -553,12 +562,48 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         }
 
         /**
+         * Get the length of the edge.
+         *
+         * @return the edge length
+         */
+        public double getLength() {
+            return length;
+        }
+
+        /**
          * Get the wall thickness of the edge.
          *
          * @return the edge wall thickness
          */
         public double getWall() {
             return wall;
+        }
+
+        /**
+         * Get the shear stress of the edge.
+         *
+         * @return the edge shear stress
+         */
+        public double getShear() {
+            return shear;
+        }
+
+        /**
+         * Get the circumferential stress of the edge.
+         *
+         * @return the edge circumferential stress
+         */
+        public double getCircum() {
+            return circum;
+        }
+
+        /**
+         * Get the volumetric flow rate of the edge.
+         *
+         * @return the edge volumetric flow rate
+         */
+        public double getFlow() {
+            return flow;
         }
     }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
@@ -18,13 +18,11 @@ import static arcade.patch.env.component.PatchComponentSitesGraphUtilities.*;
 /**
  * Factory for building a {@link Graph} for {@link PatchComponentSitesGraph}.
  *
- * <p>
- * Graph can be initialized in two ways:
+ * <p>Graph can be initialized in two ways:
  *
  * <ul>
- * <li>pattern layout that matches the structure used by
- * {@link PatchComponentSitesPattern}
- * <li>root layout grown from a specified root system using motifs
+ *   <li>pattern layout that matches the structure used by {@link PatchComponentSitesPattern}
+ *   <li>root layout grown from a specified root system using motifs
  * </ul>
  */
 public abstract class PatchComponentSitesGraphFactory {
@@ -212,7 +210,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Calculates the column of the pattern based on offset and index.
      *
-     * @param i      the index in the x direction
+     * @param i the index in the x direction
      * @param offset the lattice offset
      * @return the column index
      */
@@ -221,8 +219,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Calculates the row of the pattern based on offset and index.
      *
-     * @param i      the index in the x direction
-     * @param j      the index in the y direction
+     * @param i the index in the x direction
+     * @param j the index in the y direction
      * @param offset the lattice offset
      * @return the row index
      */
@@ -241,8 +239,8 @@ public abstract class PatchComponentSitesGraphFactory {
      *
      * @param fromX the x coordinate of the node the edge is from
      * @param fromY the y coordinate of the node the edge is from
-     * @param toX   the x coordinate of the node the edge is to
-     * @param toY   the y coordinate of the node the edge is to
+     * @param toX the x coordinate of the node the edge is to
+     * @param toY the y coordinate of the node the edge is to
      * @return the code for the edge direction
      */
     abstract EdgeDirection getDirection(int fromX, int fromY, int toX, int toY);
@@ -250,12 +248,12 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a root motif to the graph.
      *
-     * @param graph   the graph instance
-     * @param node0   the node the motif starts at
-     * @param dir     the direction code of the root
-     * @param type    the root type
+     * @param graph the graph instance
+     * @param node0 the node the motif starts at
+     * @param dir the direction code of the root
+     * @param type the root type
      * @param offsets the list of offsets for line roots, null otherwise
-     * @param random  the random number generator
+     * @param random the random number generator
      * @return the bag of active edges
      */
     abstract Bag addRoot(
@@ -269,12 +267,12 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds an edge motif to the graph.
      *
-     * @param graph  the graph instance
-     * @param node0  the node the motif starts at
-     * @param edge0  the edge the motif is being added to
-     * @param type   the edge type
-     * @param level  the graph resolution level
-     * @param motif  the motif type
+     * @param graph the graph instance
+     * @param node0 the node the motif starts at
+     * @param edge0 the edge the motif is being added to
+     * @param type the edge type
+     * @param level the graph resolution level
+     * @param motif the motif type
      * @param random the random number generator
      * @return the bag of active edges
      */
@@ -290,10 +288,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a capillary segment joining edges of different types to the graph.
      *
-     * @param graph  the graph instance
-     * @param node0  the node the segment starts at
-     * @param dir    the direction code for the segment
-     * @param level  the graph resolution level
+     * @param graph the graph instance
+     * @param node0 the node the segment starts at
+     * @param dir the direction code for the segment
+     * @param level the graph resolution level
      * @param random the random number generator
      */
     abstract void addSegment(
@@ -306,11 +304,11 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a connection joining edges of the same type to the graph.
      *
-     * @param graph  the graph instance
-     * @param node0  the node the connection starts at
-     * @param dir    the direction code for the segment
-     * @param type   the connection type
-     * @param level  the graph resolution level
+     * @param graph the graph instance
+     * @param node0 the node the connection starts at
+     * @param dir the direction code for the segment
+     * @param type the connection type
+     * @param level the graph resolution level
      * @param random the random number generator
      */
     abstract void addConnection(
@@ -332,7 +330,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets the length of the given edge.
      *
-     * @param edge  the edge object
+     * @param edge the edge object
      * @param level the graph resolution level
      * @return the length of the edge
      */
@@ -348,10 +346,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates a {@link Root} for graph sites using a root layout.
      *
-     * @param border  the border the root extends from
+     * @param border the border the root extends from
      * @param percent the percentage distance along the border
-     * @param type    the root type
-     * @param level   the graph resolution level
+     * @param type the root type
+     * @param level the graph resolution level
      * @return a {@link Root} object
      */
     abstract Root createRoot(Border border, double percent, EdgeType type, EdgeLevel level);
@@ -359,10 +357,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates offsets for a {@link Root} for graph sites using a root layout.
      *
-     * @param border  the border the root extends from
+     * @param border the border the root extends from
      * @param percent the percentage distance in the perpendicular direction
-     * @param level   the graph resolution level
-     * @param random  the random number generator
+     * @param level the graph resolution level
+     * @param random the random number generator
      * @return a list of offsets
      */
     abstract EdgeDirection[] createRootOffsets(
@@ -388,10 +386,10 @@ public abstract class PatchComponentSitesGraphFactory {
         /**
          * Creates a {@code Root} object for generating root graphs.
          *
-         * @param x    the x coordinate
-         * @param y    the y coordinate
+         * @param x the x coordinate
+         * @param y the y coordinate
          * @param type the edge type
-         * @param dir  the direction code of the root
+         * @param dir the direction code of the root
          */
         Root(int x, int y, EdgeType type, EdgeDirection dir) {
             node = new SiteNode(x, y, 0);
@@ -403,7 +401,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets direction code for an edge.
      *
-     * @param edge  the edge object
+     * @param edge the edge object
      * @param level the graph resolution level
      * @return the code for the edge direction
      */
@@ -414,8 +412,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets direction code for an edge.
      *
-     * @param from  the node the edge is from
-     * @param to    the node the edge is to
+     * @param from the node the edge is from
+     * @param to the node the edge is to
      * @param level the graph resolution level
      * @return the code for the edge direction
      */
@@ -428,9 +426,9 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates a node offset in the given direction.
      *
-     * @param node   the node of the initial location
+     * @param node the node of the initial location
      * @param offset the offset direction
-     * @param level  the graph resolution level
+     * @param level the graph resolution level
      * @return an offset node
      */
     SiteNode offsetNode(SiteNode node, EdgeDirection offset, EdgeLevel level) {
@@ -464,7 +462,7 @@ public abstract class PatchComponentSitesGraphFactory {
         }
 
         // Traverse graph from capillaries to calculate radii.
-        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
+        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
         updateRadii(graph, caps, CalculationType.UPSTREAM_PATTERN, random);
         updateRadii(graph, caps, CalculationType.DOWNSTREAM_PATTERN, random);
 
@@ -534,27 +532,30 @@ public abstract class PatchComponentSitesGraphFactory {
             for (SiteEdge edge1 : set) {
                 if (graph.getOutDegree(edge1.getTo()) == 1) {
                     int scale1 = scales.get(edge1);
-                    EdgeDirection dir1 = getDirection(
-                            edge1.getFrom().getX() / scale1,
-                            edge1.getFrom().getY() / scale1,
-                            edge1.getTo().getX() / scale1,
-                            edge1.getTo().getY() / scale1);
+                    EdgeDirection dir1 =
+                            getDirection(
+                                    edge1.getFrom().getX() / scale1,
+                                    edge1.getFrom().getY() / scale1,
+                                    edge1.getTo().getX() / scale1,
+                                    edge1.getTo().getY() / scale1);
 
                     SiteEdge edge2 = (SiteEdge) edge1.getEdgesOut().get(0);
                     int scale2 = scales.get(edge2);
-                    EdgeDirection dir2 = getDirection(
-                            edge2.getFrom().getX() / scale2,
-                            edge2.getFrom().getY() / scale2,
-                            edge2.getTo().getX() / scale2,
-                            edge2.getTo().getY() / scale2);
+                    EdgeDirection dir2 =
+                            getDirection(
+                                    edge2.getFrom().getX() / scale2,
+                                    edge2.getFrom().getY() / scale2,
+                                    edge2.getTo().getX() / scale2,
+                                    edge2.getTo().getY() / scale2);
 
                     // Join edges that are the same direction and type.
                     if (dir1 == dir2 && edge1.type == edge2.type) {
-                        SiteEdge join = new SiteEdge(
-                                edge1.getFrom(),
-                                edge2.getTo(),
-                                edge1.type,
-                                EdgeLevel.VARIABLE);
+                        SiteEdge join =
+                                new SiteEdge(
+                                        edge1.getFrom(),
+                                        edge2.getTo(),
+                                        edge1.type,
+                                        EdgeLevel.VARIABLE);
                         scales.put(join, scale1 + scale2);
 
                         // Set length to be sum and radius to be average of the
@@ -587,7 +588,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Initializes graph with edges and nodes in a root layout.
      *
-     * @param random      the random number generator
+     * @param random the random number generator
      * @param graphLayout the specification for layout of roots
      * @return a graph instance with root layout
      */
@@ -674,11 +675,11 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Updates hemodynamic properties for graph sites with root layouts.
      *
-     * @param graph    the graph instance
+     * @param graph the graph instance
      * @param arteries the list of artery edges
-     * @param veins    the list of vein edges
-     * @param level    the graph resolution level
-     * @param random   the random number generator
+     * @param veins the list of vein edges
+     * @param level the graph resolution level
+     * @param random the random number generator
      */
     private void updateRootGraph(
             Graph graph,
@@ -691,14 +692,14 @@ public abstract class PatchComponentSitesGraphFactory {
 
         // Store upper level capillaries.
         if (level != EdgeLevel.LEVEL_1) {
-            caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
+            caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
             for (SiteEdge edge : caps) {
                 graph.removeEdge(edge);
             }
         }
 
         // Get all leaves and update radii.
-        list = getLeavesByType(graph, new EdgeType[] { EdgeType.ARTERY, EdgeType.VEIN });
+        list = getLeavesByType(graph, new EdgeType[] {EdgeType.ARTERY, EdgeType.VEIN});
         updateRadii(graph, list, CalculationType.UPSTREAM_ALL);
 
         // Replace level 1 edges capillaries.
@@ -711,16 +712,17 @@ public abstract class PatchComponentSitesGraphFactory {
         addSegments(graph, level, random);
         addConnections(graph, level, random);
 
-        caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
+        caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
 
         // Get capillaries and arterioles and update radii.
         switch (level) {
             case LEVEL_1:
-                list = getEdgeByType(
-                        graph, new EdgeType[] { EdgeType.CAPILLARY, EdgeType.ARTERIOLE });
+                list =
+                        getEdgeByType(
+                                graph, new EdgeType[] {EdgeType.CAPILLARY, EdgeType.ARTERIOLE});
                 break;
             case LEVEL_2:
-                list = getEdgeByType(graph, new EdgeType[] { EdgeType.ARTERIOLE }, level);
+                list = getEdgeByType(graph, new EdgeType[] {EdgeType.ARTERIOLE}, level);
                 list.addAll(caps);
                 break;
             default:
@@ -735,10 +737,10 @@ public abstract class PatchComponentSitesGraphFactory {
         // Get capillaries and venules and update radii.
         switch (level) {
             case LEVEL_1:
-                list = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY, EdgeType.VENULE });
+                list = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY, EdgeType.VENULE});
                 break;
             case LEVEL_2:
-                list = getEdgeByType(graph, new EdgeType[] { EdgeType.VENULE }, level);
+                list = getEdgeByType(graph, new EdgeType[] {EdgeType.VENULE}, level);
                 list.addAll(caps);
                 break;
             default:
@@ -808,13 +810,14 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Refines the graph for graph sites with root layouts.
      *
-     * @param graph    the graph instance
+     * @param graph the graph instance
      * @param arteries the list of artery edges
-     * @param veins    the list of vein edges
+     * @param veins the list of vein edges
      */
     private void refineRootGraph(Graph graph, ArrayList<Root> arteries, ArrayList<Root> veins) {
         // Reverse edges that are veins and venules.
-        ArrayList<SiteEdge> reverse = getEdgeByType(graph, new EdgeType[] { EdgeType.VEIN, EdgeType.VENULE });
+        ArrayList<SiteEdge> reverse =
+                getEdgeByType(graph, new EdgeType[] {EdgeType.VEIN, EdgeType.VENULE});
         for (SiteEdge edge : reverse) {
             graph.reverseEdge(edge);
         }
@@ -823,7 +826,7 @@ public abstract class PatchComponentSitesGraphFactory {
         reversePressures(graph);
 
         // Check for non-connected graph.
-        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
+        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
         if (caps.size() < 1) {
             graph.clear();
             return;
@@ -843,7 +846,7 @@ public abstract class PatchComponentSitesGraphFactory {
         }
 
         // Get all capillaries and update radii.
-        ArrayList<SiteEdge> list = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
+        ArrayList<SiteEdge> list = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
         updateRadii(graph, list, CalculationType.UPSTREAM_ARTERIES);
         updateRadii(graph, list, CalculationType.DOWNSTREAM_VEINS);
 
@@ -952,16 +955,17 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Remodels sites based on shear stress.
      *
-     * @param graph  the graph instance
-     * @param level  the graph resolution level
+     * @param graph the graph instance
+     * @param level the graph resolution level
      * @param random the random number generator
      * @return the fraction of edges remodeled
      */
     private double remodelRootGraph(Graph graph, EdgeLevel level, MersenneTwisterFast random) {
         // Remove capillaries, arterioles, and venules.
-        ArrayList<SiteEdge> list = getEdgeByType(
-                graph,
-                new EdgeType[] { EdgeType.CAPILLARY, EdgeType.VENULE, EdgeType.ARTERIOLE });
+        ArrayList<SiteEdge> list =
+                getEdgeByType(
+                        graph,
+                        new EdgeType[] {EdgeType.CAPILLARY, EdgeType.VENULE, EdgeType.ARTERIOLE});
         for (SiteEdge edge : list) {
             graph.removeEdge(edge);
         }
@@ -1009,24 +1013,26 @@ public abstract class PatchComponentSitesGraphFactory {
         for (Object obj : allEdges) {
             SiteEdge edge = (SiteEdge) obj;
             if (edge.tag == EdgeTag.ADD && graph.getDegree(edge.getTo()) < 3) {
-                Bag bag1 = addMotif(
-                        graph,
-                        edge.getTo(),
-                        edge,
-                        edge.type,
-                        level,
-                        EdgeMotif.TRIPLE,
-                        random);
+                Bag bag1 =
+                        addMotif(
+                                graph,
+                                edge.getTo(),
+                                edge,
+                                edge.type,
+                                level,
+                                EdgeMotif.TRIPLE,
+                                random);
 
                 SiteEdge edge1 = (SiteEdge) bag1.get(0);
-                Bag bag2 = addMotif(
-                        graph,
-                        edge1.getTo(),
-                        edge,
-                        edge.type,
-                        level,
-                        EdgeMotif.DOUBLE,
-                        random);
+                Bag bag2 =
+                        addMotif(
+                                graph,
+                                edge1.getTo(),
+                                edge,
+                                edge.type,
+                                level,
+                                EdgeMotif.DOUBLE,
+                                random);
 
                 SiteEdge edge2 = (SiteEdge) bag2.get(0);
                 addMotif(graph, edge2.getTo(), edge, edge.type, level, EdgeMotif.SINGLE, random);
@@ -1110,10 +1116,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds motifs to graph until no additional motifs can be added.
      *
-     * @param graph  the graph instance
-     * @param bag    the current bag of active edges
-     * @param level  the graph resolution level
-     * @param motif  the motif code
+     * @param graph the graph instance
+     * @param bag the current bag of active edges
+     * @param level the graph resolution level
+     * @param motif the motif code
      * @param random the random number generator
      * @return the updated bag of active edges
      */
@@ -1162,8 +1168,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds segments to graph between arteries and veins.
      *
-     * @param graph  the graph instance
-     * @param level  the graph resolution level
+     * @param graph the graph instance
+     * @param level the graph resolution level
      * @param random the random number generator
      */
     private void addSegments(Graph graph, EdgeLevel level, MersenneTwisterFast random) {
@@ -1186,8 +1192,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds connections to graphs between arteries or between veins.
      *
-     * @param graph  the graph instance
-     * @param level  the graph resolution level
+     * @param graph the graph instance
+     * @param level the graph resolution level
      * @param random the random number generator
      */
     private void addConnections(Graph graph, EdgeLevel level, MersenneTwisterFast random) {

--- a/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
@@ -18,11 +18,13 @@ import static arcade.patch.env.component.PatchComponentSitesGraphUtilities.*;
 /**
  * Factory for building a {@link Graph} for {@link PatchComponentSitesGraph}.
  *
- * <p>Graph can be initialized in two ways:
+ * <p>
+ * Graph can be initialized in two ways:
  *
  * <ul>
- *   <li>pattern layout that matches the structure used by {@link PatchComponentSitesPattern}
- *   <li>root layout grown from a specified root system using motifs
+ * <li>pattern layout that matches the structure used by
+ * {@link PatchComponentSitesPattern}
+ * <li>root layout grown from a specified root system using motifs
  * </ul>
  */
 public abstract class PatchComponentSitesGraphFactory {
@@ -42,7 +44,7 @@ public abstract class PatchComponentSitesGraphFactory {
     }
 
     /** Edge types. */
-    enum EdgeType {
+    public enum EdgeType {
         /** Code for arteriole edge type. */
         ARTERIOLE(EdgeCategory.ARTERY),
 
@@ -210,7 +212,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Calculates the column of the pattern based on offset and index.
      *
-     * @param i the index in the x direction
+     * @param i      the index in the x direction
      * @param offset the lattice offset
      * @return the column index
      */
@@ -219,8 +221,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Calculates the row of the pattern based on offset and index.
      *
-     * @param i the index in the x direction
-     * @param j the index in the y direction
+     * @param i      the index in the x direction
+     * @param j      the index in the y direction
      * @param offset the lattice offset
      * @return the row index
      */
@@ -239,8 +241,8 @@ public abstract class PatchComponentSitesGraphFactory {
      *
      * @param fromX the x coordinate of the node the edge is from
      * @param fromY the y coordinate of the node the edge is from
-     * @param toX the x coordinate of the node the edge is to
-     * @param toY the y coordinate of the node the edge is to
+     * @param toX   the x coordinate of the node the edge is to
+     * @param toY   the y coordinate of the node the edge is to
      * @return the code for the edge direction
      */
     abstract EdgeDirection getDirection(int fromX, int fromY, int toX, int toY);
@@ -248,12 +250,12 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a root motif to the graph.
      *
-     * @param graph the graph instance
-     * @param node0 the node the motif starts at
-     * @param dir the direction code of the root
-     * @param type the root type
+     * @param graph   the graph instance
+     * @param node0   the node the motif starts at
+     * @param dir     the direction code of the root
+     * @param type    the root type
      * @param offsets the list of offsets for line roots, null otherwise
-     * @param random the random number generator
+     * @param random  the random number generator
      * @return the bag of active edges
      */
     abstract Bag addRoot(
@@ -267,12 +269,12 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds an edge motif to the graph.
      *
-     * @param graph the graph instance
-     * @param node0 the node the motif starts at
-     * @param edge0 the edge the motif is being added to
-     * @param type the edge type
-     * @param level the graph resolution level
-     * @param motif the motif type
+     * @param graph  the graph instance
+     * @param node0  the node the motif starts at
+     * @param edge0  the edge the motif is being added to
+     * @param type   the edge type
+     * @param level  the graph resolution level
+     * @param motif  the motif type
      * @param random the random number generator
      * @return the bag of active edges
      */
@@ -288,10 +290,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a capillary segment joining edges of different types to the graph.
      *
-     * @param graph the graph instance
-     * @param node0 the node the segment starts at
-     * @param dir the direction code for the segment
-     * @param level the graph resolution level
+     * @param graph  the graph instance
+     * @param node0  the node the segment starts at
+     * @param dir    the direction code for the segment
+     * @param level  the graph resolution level
      * @param random the random number generator
      */
     abstract void addSegment(
@@ -304,11 +306,11 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds a connection joining edges of the same type to the graph.
      *
-     * @param graph the graph instance
-     * @param node0 the node the connection starts at
-     * @param dir the direction code for the segment
-     * @param type the connection type
-     * @param level the graph resolution level
+     * @param graph  the graph instance
+     * @param node0  the node the connection starts at
+     * @param dir    the direction code for the segment
+     * @param type   the connection type
+     * @param level  the graph resolution level
      * @param random the random number generator
      */
     abstract void addConnection(
@@ -330,7 +332,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets the length of the given edge.
      *
-     * @param edge the edge object
+     * @param edge  the edge object
      * @param level the graph resolution level
      * @return the length of the edge
      */
@@ -346,10 +348,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates a {@link Root} for graph sites using a root layout.
      *
-     * @param border the border the root extends from
+     * @param border  the border the root extends from
      * @param percent the percentage distance along the border
-     * @param type the root type
-     * @param level the graph resolution level
+     * @param type    the root type
+     * @param level   the graph resolution level
      * @return a {@link Root} object
      */
     abstract Root createRoot(Border border, double percent, EdgeType type, EdgeLevel level);
@@ -357,10 +359,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates offsets for a {@link Root} for graph sites using a root layout.
      *
-     * @param border the border the root extends from
+     * @param border  the border the root extends from
      * @param percent the percentage distance in the perpendicular direction
-     * @param level the graph resolution level
-     * @param random the random number generator
+     * @param level   the graph resolution level
+     * @param random  the random number generator
      * @return a list of offsets
      */
     abstract EdgeDirection[] createRootOffsets(
@@ -386,10 +388,10 @@ public abstract class PatchComponentSitesGraphFactory {
         /**
          * Creates a {@code Root} object for generating root graphs.
          *
-         * @param x the x coordinate
-         * @param y the y coordinate
+         * @param x    the x coordinate
+         * @param y    the y coordinate
          * @param type the edge type
-         * @param dir the direction code of the root
+         * @param dir  the direction code of the root
          */
         Root(int x, int y, EdgeType type, EdgeDirection dir) {
             node = new SiteNode(x, y, 0);
@@ -401,7 +403,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets direction code for an edge.
      *
-     * @param edge the edge object
+     * @param edge  the edge object
      * @param level the graph resolution level
      * @return the code for the edge direction
      */
@@ -412,8 +414,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Gets direction code for an edge.
      *
-     * @param from the node the edge is from
-     * @param to the node the edge is to
+     * @param from  the node the edge is from
+     * @param to    the node the edge is to
      * @param level the graph resolution level
      * @return the code for the edge direction
      */
@@ -426,9 +428,9 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Creates a node offset in the given direction.
      *
-     * @param node the node of the initial location
+     * @param node   the node of the initial location
      * @param offset the offset direction
-     * @param level the graph resolution level
+     * @param level  the graph resolution level
      * @return an offset node
      */
     SiteNode offsetNode(SiteNode node, EdgeDirection offset, EdgeLevel level) {
@@ -462,7 +464,7 @@ public abstract class PatchComponentSitesGraphFactory {
         }
 
         // Traverse graph from capillaries to calculate radii.
-        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
+        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
         updateRadii(graph, caps, CalculationType.UPSTREAM_PATTERN, random);
         updateRadii(graph, caps, CalculationType.DOWNSTREAM_PATTERN, random);
 
@@ -532,30 +534,27 @@ public abstract class PatchComponentSitesGraphFactory {
             for (SiteEdge edge1 : set) {
                 if (graph.getOutDegree(edge1.getTo()) == 1) {
                     int scale1 = scales.get(edge1);
-                    EdgeDirection dir1 =
-                            getDirection(
-                                    edge1.getFrom().getX() / scale1,
-                                    edge1.getFrom().getY() / scale1,
-                                    edge1.getTo().getX() / scale1,
-                                    edge1.getTo().getY() / scale1);
+                    EdgeDirection dir1 = getDirection(
+                            edge1.getFrom().getX() / scale1,
+                            edge1.getFrom().getY() / scale1,
+                            edge1.getTo().getX() / scale1,
+                            edge1.getTo().getY() / scale1);
 
                     SiteEdge edge2 = (SiteEdge) edge1.getEdgesOut().get(0);
                     int scale2 = scales.get(edge2);
-                    EdgeDirection dir2 =
-                            getDirection(
-                                    edge2.getFrom().getX() / scale2,
-                                    edge2.getFrom().getY() / scale2,
-                                    edge2.getTo().getX() / scale2,
-                                    edge2.getTo().getY() / scale2);
+                    EdgeDirection dir2 = getDirection(
+                            edge2.getFrom().getX() / scale2,
+                            edge2.getFrom().getY() / scale2,
+                            edge2.getTo().getX() / scale2,
+                            edge2.getTo().getY() / scale2);
 
                     // Join edges that are the same direction and type.
                     if (dir1 == dir2 && edge1.type == edge2.type) {
-                        SiteEdge join =
-                                new SiteEdge(
-                                        edge1.getFrom(),
-                                        edge2.getTo(),
-                                        edge1.type,
-                                        EdgeLevel.VARIABLE);
+                        SiteEdge join = new SiteEdge(
+                                edge1.getFrom(),
+                                edge2.getTo(),
+                                edge1.type,
+                                EdgeLevel.VARIABLE);
                         scales.put(join, scale1 + scale2);
 
                         // Set length to be sum and radius to be average of the
@@ -588,7 +587,7 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Initializes graph with edges and nodes in a root layout.
      *
-     * @param random the random number generator
+     * @param random      the random number generator
      * @param graphLayout the specification for layout of roots
      * @return a graph instance with root layout
      */
@@ -675,11 +674,11 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Updates hemodynamic properties for graph sites with root layouts.
      *
-     * @param graph the graph instance
+     * @param graph    the graph instance
      * @param arteries the list of artery edges
-     * @param veins the list of vein edges
-     * @param level the graph resolution level
-     * @param random the random number generator
+     * @param veins    the list of vein edges
+     * @param level    the graph resolution level
+     * @param random   the random number generator
      */
     private void updateRootGraph(
             Graph graph,
@@ -692,14 +691,14 @@ public abstract class PatchComponentSitesGraphFactory {
 
         // Store upper level capillaries.
         if (level != EdgeLevel.LEVEL_1) {
-            caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
+            caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
             for (SiteEdge edge : caps) {
                 graph.removeEdge(edge);
             }
         }
 
         // Get all leaves and update radii.
-        list = getLeavesByType(graph, new EdgeType[] {EdgeType.ARTERY, EdgeType.VEIN});
+        list = getLeavesByType(graph, new EdgeType[] { EdgeType.ARTERY, EdgeType.VEIN });
         updateRadii(graph, list, CalculationType.UPSTREAM_ALL);
 
         // Replace level 1 edges capillaries.
@@ -712,17 +711,16 @@ public abstract class PatchComponentSitesGraphFactory {
         addSegments(graph, level, random);
         addConnections(graph, level, random);
 
-        caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
+        caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
 
         // Get capillaries and arterioles and update radii.
         switch (level) {
             case LEVEL_1:
-                list =
-                        getEdgeByType(
-                                graph, new EdgeType[] {EdgeType.CAPILLARY, EdgeType.ARTERIOLE});
+                list = getEdgeByType(
+                        graph, new EdgeType[] { EdgeType.CAPILLARY, EdgeType.ARTERIOLE });
                 break;
             case LEVEL_2:
-                list = getEdgeByType(graph, new EdgeType[] {EdgeType.ARTERIOLE}, level);
+                list = getEdgeByType(graph, new EdgeType[] { EdgeType.ARTERIOLE }, level);
                 list.addAll(caps);
                 break;
             default:
@@ -737,10 +735,10 @@ public abstract class PatchComponentSitesGraphFactory {
         // Get capillaries and venules and update radii.
         switch (level) {
             case LEVEL_1:
-                list = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY, EdgeType.VENULE});
+                list = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY, EdgeType.VENULE });
                 break;
             case LEVEL_2:
-                list = getEdgeByType(graph, new EdgeType[] {EdgeType.VENULE}, level);
+                list = getEdgeByType(graph, new EdgeType[] { EdgeType.VENULE }, level);
                 list.addAll(caps);
                 break;
             default:
@@ -810,14 +808,13 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Refines the graph for graph sites with root layouts.
      *
-     * @param graph the graph instance
+     * @param graph    the graph instance
      * @param arteries the list of artery edges
-     * @param veins the list of vein edges
+     * @param veins    the list of vein edges
      */
     private void refineRootGraph(Graph graph, ArrayList<Root> arteries, ArrayList<Root> veins) {
         // Reverse edges that are veins and venules.
-        ArrayList<SiteEdge> reverse =
-                getEdgeByType(graph, new EdgeType[] {EdgeType.VEIN, EdgeType.VENULE});
+        ArrayList<SiteEdge> reverse = getEdgeByType(graph, new EdgeType[] { EdgeType.VEIN, EdgeType.VENULE });
         for (SiteEdge edge : reverse) {
             graph.reverseEdge(edge);
         }
@@ -826,7 +823,7 @@ public abstract class PatchComponentSitesGraphFactory {
         reversePressures(graph);
 
         // Check for non-connected graph.
-        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
+        ArrayList<SiteEdge> caps = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
         if (caps.size() < 1) {
             graph.clear();
             return;
@@ -846,7 +843,7 @@ public abstract class PatchComponentSitesGraphFactory {
         }
 
         // Get all capillaries and update radii.
-        ArrayList<SiteEdge> list = getEdgeByType(graph, new EdgeType[] {EdgeType.CAPILLARY});
+        ArrayList<SiteEdge> list = getEdgeByType(graph, new EdgeType[] { EdgeType.CAPILLARY });
         updateRadii(graph, list, CalculationType.UPSTREAM_ARTERIES);
         updateRadii(graph, list, CalculationType.DOWNSTREAM_VEINS);
 
@@ -955,17 +952,16 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Remodels sites based on shear stress.
      *
-     * @param graph the graph instance
-     * @param level the graph resolution level
+     * @param graph  the graph instance
+     * @param level  the graph resolution level
      * @param random the random number generator
      * @return the fraction of edges remodeled
      */
     private double remodelRootGraph(Graph graph, EdgeLevel level, MersenneTwisterFast random) {
         // Remove capillaries, arterioles, and venules.
-        ArrayList<SiteEdge> list =
-                getEdgeByType(
-                        graph,
-                        new EdgeType[] {EdgeType.CAPILLARY, EdgeType.VENULE, EdgeType.ARTERIOLE});
+        ArrayList<SiteEdge> list = getEdgeByType(
+                graph,
+                new EdgeType[] { EdgeType.CAPILLARY, EdgeType.VENULE, EdgeType.ARTERIOLE });
         for (SiteEdge edge : list) {
             graph.removeEdge(edge);
         }
@@ -1013,26 +1009,24 @@ public abstract class PatchComponentSitesGraphFactory {
         for (Object obj : allEdges) {
             SiteEdge edge = (SiteEdge) obj;
             if (edge.tag == EdgeTag.ADD && graph.getDegree(edge.getTo()) < 3) {
-                Bag bag1 =
-                        addMotif(
-                                graph,
-                                edge.getTo(),
-                                edge,
-                                edge.type,
-                                level,
-                                EdgeMotif.TRIPLE,
-                                random);
+                Bag bag1 = addMotif(
+                        graph,
+                        edge.getTo(),
+                        edge,
+                        edge.type,
+                        level,
+                        EdgeMotif.TRIPLE,
+                        random);
 
                 SiteEdge edge1 = (SiteEdge) bag1.get(0);
-                Bag bag2 =
-                        addMotif(
-                                graph,
-                                edge1.getTo(),
-                                edge,
-                                edge.type,
-                                level,
-                                EdgeMotif.DOUBLE,
-                                random);
+                Bag bag2 = addMotif(
+                        graph,
+                        edge1.getTo(),
+                        edge,
+                        edge.type,
+                        level,
+                        EdgeMotif.DOUBLE,
+                        random);
 
                 SiteEdge edge2 = (SiteEdge) bag2.get(0);
                 addMotif(graph, edge2.getTo(), edge, edge.type, level, EdgeMotif.SINGLE, random);
@@ -1116,10 +1110,10 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds motifs to graph until no additional motifs can be added.
      *
-     * @param graph the graph instance
-     * @param bag the current bag of active edges
-     * @param level the graph resolution level
-     * @param motif the motif code
+     * @param graph  the graph instance
+     * @param bag    the current bag of active edges
+     * @param level  the graph resolution level
+     * @param motif  the motif code
      * @param random the random number generator
      * @return the updated bag of active edges
      */
@@ -1168,8 +1162,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds segments to graph between arteries and veins.
      *
-     * @param graph the graph instance
-     * @param level the graph resolution level
+     * @param graph  the graph instance
+     * @param level  the graph resolution level
      * @param random the random number generator
      */
     private void addSegments(Graph graph, EdgeLevel level, MersenneTwisterFast random) {
@@ -1192,8 +1186,8 @@ public abstract class PatchComponentSitesGraphFactory {
     /**
      * Adds connections to graphs between arteries or between veins.
      *
-     * @param graph the graph instance
-     * @param level the graph resolution level
+     * @param graph  the graph instance
+     * @param level  the graph resolution level
      * @param random the random number generator
      */
     private void addConnections(Graph graph, EdgeLevel level, MersenneTwisterFast random) {

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -149,6 +149,11 @@ public abstract class PatchSimulation extends SimState implements Simulation {
         return components.get(key);
     }
 
+    /**
+     * Gets the set of keys for the component hash set.
+     *
+     * @return the set of component keys
+     */
     public Set<String> getComponentKeys() {
         return components.keySet();
     }

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -3,6 +3,7 @@ package arcade.patch.sim;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 import sim.engine.Schedule;
 import sim.engine.SimState;
 import arcade.core.agent.action.Action;
@@ -146,6 +147,10 @@ public abstract class PatchSimulation extends SimState implements Simulation {
     @Override
     public final Component getComponent(String key) {
         return components.get(key);
+    }
+
+    public Set<String> getComponentKeys() {
+        return components.keySet();
     }
 
     /**

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -24,6 +24,7 @@ import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.lattice.PatchLattice;
 import arcade.patch.env.lattice.PatchLatticeFactory;
 import arcade.patch.env.location.PatchLocationFactory;
+import arcade.patch.sim.output.PatchOutputSaver;
 
 /** Abstract implementation for patch {@link Simulation} instances. */
 public abstract class PatchSimulation extends SimState implements Simulation {
@@ -356,6 +357,11 @@ public abstract class PatchSimulation extends SimState implements Simulation {
             int tick = (int) schedule.getTime() + 1;
             series.saver.saveCells(tick);
             series.saver.saveLocations(tick);
+
+            PatchOutputSaver patchSaver = (PatchOutputSaver) series.saver;
+            if (patchSaver.saveGraph) {
+                patchSaver.saveGraphComponents(tick);
+            }
         }
     }
 }

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -25,7 +25,6 @@ import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.lattice.PatchLattice;
 import arcade.patch.env.lattice.PatchLatticeFactory;
 import arcade.patch.env.location.PatchLocationFactory;
-import arcade.patch.sim.output.PatchOutputSaver;
 
 /** Abstract implementation for patch {@link Simulation} instances. */
 public abstract class PatchSimulation extends SimState implements Simulation {
@@ -365,11 +364,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
             series.saver.schedule(schedule, series.getInterval());
         } else {
             int tick = (int) schedule.getTime() + 1;
-            series.saver.saveCells(tick);
-            series.saver.saveLocations(tick);
-
-            PatchOutputSaver patchSaver = (PatchOutputSaver) series.saver;
-            patchSaver.saveComponents(tick);
+            series.saver.save(tick);
         }
     }
 }

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -369,9 +369,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
             series.saver.saveLocations(tick);
 
             PatchOutputSaver patchSaver = (PatchOutputSaver) series.saver;
-            if (patchSaver.saveGraph) {
-                patchSaver.saveGraphComponents(tick);
-            }
+            patchSaver.saveComponents(tick);
         }
     }
 }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -2,8 +2,11 @@ package arcade.patch.sim.output;
 
 import com.google.gson.Gson;
 import sim.engine.SimState;
+import arcade.core.env.component.Component;
 import arcade.core.sim.Series;
 import arcade.core.sim.output.OutputSaver;
+import arcade.patch.env.component.PatchComponentSitesGraph;
+import arcade.patch.sim.PatchSimulation;
 
 /** Custom saver for patch-specific serialization. */
 public final class PatchOutputSaver extends OutputSaver {
@@ -24,7 +27,19 @@ public final class PatchOutputSaver extends OutputSaver {
     }
 
     public void saveGraphComponents(int tick) {
-        throw new UnsupportedOperationException("saveGraphComponents not implemented");
+        for (String componentKey : ((PatchSimulation) sim).getComponentKeys()) {
+            Component component = sim.getComponent(componentKey);
+            if (component instanceof PatchComponentSitesGraph) {
+                String json =
+                        gson.toJson(
+                                (PatchComponentSitesGraph) component,
+                                PatchComponentSitesGraph.class);
+                String path = prefix + String.format("_%06d." + componentKey + ".GRAPH.json", tick);
+                write(path, format(json, FORMAT_ELEMENTS));
+            } else {
+                continue;
+            }
+        }
     }
 
     @Override

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -24,7 +24,7 @@ public final class PatchOutputSaver extends OutputSaver {
     }
 
     public void saveGraphComponents(int tick) {
-         raise UnsupportedOperationException("saveGraphComponents not implemented");
+        throw new UnsupportedOperationException("saveGraphComponents not implemented");
     }
 
     @Override

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -10,13 +10,15 @@ import arcade.patch.sim.PatchSimulation;
 
 /** Custom saver for patch-specific serialization. */
 public final class PatchOutputSaver extends OutputSaver {
+
+    /** {@code true} to save graph components, {@code false} otherwise. */
+    public boolean saveGraph;
+
     /**
      * Creates an {@code PatchOutputSaver} for the series.
      *
      * @param series the simulation series
      */
-    public boolean saveGraph;
-
     public PatchOutputSaver(Series series) {
         super(series);
     }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -26,6 +26,11 @@ public final class PatchOutputSaver extends OutputSaver {
         return PatchOutputSerializer.makeGSON();
     }
 
+    /**
+     * Save a list of {@link arcade.patch.env.component.PatchComponentSitesGraph} to a JSON.
+     *
+     * @param tick the simulation tick
+     */
     public void saveGraphComponents(int tick) {
         for (String componentKey : ((PatchSimulation) sim).getComponentKeys()) {
             Component component = sim.getComponent(componentKey);

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -48,9 +48,17 @@ public final class PatchOutputSaver extends OutputSaver {
     }
 
     @Override
+    public void save(int tick) {
+        super.save(tick);
+        if (saveGraph) {
+            saveComponents(tick);
+        }
+    }
+
+    @Override
     public void step(SimState simstate) {
         super.step(simstate);
         int tick = (int) simstate.schedule.getTime();
-        saveComponents(tick);
+        save(tick);
     }
 }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -1,6 +1,7 @@
 package arcade.patch.sim.output;
 
 import com.google.gson.Gson;
+import sim.engine.SimState;
 import arcade.core.sim.Series;
 import arcade.core.sim.output.OutputSaver;
 
@@ -11,6 +12,8 @@ public final class PatchOutputSaver extends OutputSaver {
      *
      * @param series the simulation series
      */
+    public boolean saveGraph;
+
     public PatchOutputSaver(Series series) {
         super(series);
     }
@@ -18,5 +21,18 @@ public final class PatchOutputSaver extends OutputSaver {
     @Override
     protected Gson makeGSON() {
         return PatchOutputSerializer.makeGSON();
+    }
+
+    public void saveGraphComponents(int tick) {
+        LOGGER.info("Saving Graph Sites!");
+    }
+
+    @Override
+    public void step(SimState simstate) {
+        super.step(simstate);
+        int tick = (int) simstate.schedule.getTime();
+        if (saveGraph) {
+            saveGraphComponents(tick);
+        }
     }
 }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -33,18 +33,16 @@ public final class PatchOutputSaver extends OutputSaver {
      *
      * @param tick the simulation tick
      */
-    public void saveGraphComponents(int tick) {
+    public void saveComponents(int tick) {
         for (String componentKey : ((PatchSimulation) sim).getComponentKeys()) {
             Component component = sim.getComponent(componentKey);
-            if (component instanceof PatchComponentSitesGraph) {
+            if (component instanceof PatchComponentSitesGraph && saveGraph) {
                 String json =
                         gson.toJson(
                                 (PatchComponentSitesGraph) component,
                                 PatchComponentSitesGraph.class);
                 String path = prefix + String.format("_%06d." + componentKey + ".GRAPH.json", tick);
                 write(path, format(json, FORMAT_ELEMENTS));
-            } else {
-                continue;
             }
         }
     }
@@ -53,8 +51,6 @@ public final class PatchOutputSaver extends OutputSaver {
     public void step(SimState simstate) {
         super.step(simstate);
         int tick = (int) simstate.schedule.getTime();
-        if (saveGraph) {
-            saveGraphComponents(tick);
-        }
+        saveComponents(tick);
     }
 }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -24,7 +24,7 @@ public final class PatchOutputSaver extends OutputSaver {
     }
 
     public void saveGraphComponents(int tick) {
-        LOGGER.info("Saving Graph Sites!");
+         raise UnsupportedOperationException("saveGraphComponents not implemented");
     }
 
     @Override

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -10,11 +10,13 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
 import arcade.core.agent.cell.CellContainer;
 import arcade.core.env.location.LocationContainer;
 import arcade.core.sim.Series;
 import arcade.core.sim.output.OutputSerializer;
 import arcade.patch.agent.cell.PatchCellContainer;
+import arcade.patch.env.component.PatchComponentSitesGraph;
 import arcade.patch.env.component.PatchComponentSitesGraph.SiteEdge;
 import arcade.patch.env.component.PatchComponentSitesGraph.SiteNode;
 import arcade.patch.env.location.Coordinate;
@@ -22,6 +24,7 @@ import arcade.patch.env.location.CoordinateUVWZ;
 import arcade.patch.env.location.CoordinateXYZ;
 import arcade.patch.env.location.PatchLocationContainer;
 import arcade.patch.sim.PatchSeries;
+import arcade.patch.util.PatchEnums.State;
 import static arcade.core.sim.Simulation.DEFAULT_LOCATION_TYPE;
 import static arcade.patch.util.PatchEnums.State;
 
@@ -39,6 +42,9 @@ import static arcade.patch.util.PatchEnums.State;
  * </ul>
  */
 public final class PatchOutputSerializer {
+
+    static Type DEFAULT_EDGE_TYPE = new TypeToken<ArrayList<LocationContainer>>() {}.getType();
+
     /** Hidden utility class constructor. */
     protected PatchOutputSerializer() {
         throw new UnsupportedOperationException();
@@ -57,6 +63,9 @@ public final class PatchOutputSerializer {
         gsonBuilder.registerTypeAdapter(DEFAULT_LOCATION_TYPE, new LocationListSerializer());
         gsonBuilder.registerTypeAdapter(CoordinateXYZ.class, new CoordinateXYZSerializer());
         gsonBuilder.registerTypeAdapter(CoordinateUVWZ.class, new CoordinateUVWZSerializer());
+        gsonBuilder.registerTypeAdapter(PatchComponentSitesGraph.class, new SitesGraphSerializer());
+        gsonBuilder.registerTypeAdapter(SiteEdge.class, new SiteEdgeSerializer());
+        gsonBuilder.registerTypeAdapter(SiteNode.class, new SiteNodeSerializer());
         return gsonBuilder.create();
     }
 
@@ -148,6 +157,22 @@ public final class PatchOutputSerializer {
             json.add("criticals", criticals);
 
             // TODO: add cycles
+
+            return json;
+        }
+    }
+
+    static class SitesGraphSerializer implements JsonSerializer<PatchComponentSitesGraph> {
+        @Override
+        public JsonElement serialize(
+                PatchComponentSitesGraph src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonArray json = new JsonArray();
+
+            for (Object obj : src.getGraph().getAllEdges()) {
+                SiteEdge e = (SiteEdge) obj;
+                JsonElement edge = context.serialize(e, SiteEdge.class);
+                json.add(edge);
+            }
 
             return json;
         }

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -10,7 +10,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
-import com.google.gson.reflect.TypeToken;
 import arcade.core.agent.cell.CellContainer;
 import arcade.core.env.location.LocationContainer;
 import arcade.core.sim.Series;
@@ -26,7 +25,6 @@ import arcade.patch.env.location.PatchLocationContainer;
 import arcade.patch.sim.PatchSeries;
 import arcade.patch.util.PatchEnums.State;
 import static arcade.core.sim.Simulation.DEFAULT_LOCATION_TYPE;
-import static arcade.patch.util.PatchEnums.State;
 
 /**
  * Container class for patch-specific object serializers.
@@ -42,9 +40,6 @@ import static arcade.patch.util.PatchEnums.State;
  * </ul>
  */
 public final class PatchOutputSerializer {
-
-    static Type DEFAULT_EDGE_TYPE = new TypeToken<ArrayList<LocationContainer>>() {}.getType();
-
     /** Hidden utility class constructor. */
     protected PatchOutputSerializer() {
         throw new UnsupportedOperationException();
@@ -162,6 +157,39 @@ public final class PatchOutputSerializer {
         }
     }
 
+    /**
+     * Serializer for {@link PatchComponentSitesGraph} objects.
+     *
+     * <p>The object is formatted as:
+     *
+     * <pre>
+     *     [
+     *         {
+     *             "from": (from),
+     *             "to": (to),
+     *             "type": (type),
+     *             "radius": (radius),
+     *             "length": (length),
+     *             "wall": (wall),
+     *             "shear": (shear),
+     *             "stress": (stress),
+     *             "flow": (flow),
+     *         },
+     *         {
+     *             "from": (from),
+     *             "to": (to),
+     *             "type": (type),
+     *             "radius": (radius),
+     *             "length": (length),
+     *             "wall": (wall),
+     *             "shear": (shear),
+     *             "stress": (stress),
+     *             "flow": (flow),
+     *         },
+     *         ...
+     *     ]
+     * </pre>
+     */
     static class SitesGraphSerializer implements JsonSerializer<PatchComponentSitesGraph> {
         @Override
         public JsonElement serialize(
@@ -178,6 +206,25 @@ public final class PatchOutputSerializer {
         }
     }
 
+    /**
+     * Serializer for {@link SiteEdge} objects.
+     *
+     * <p>The object is formatted as:
+     *
+     * <pre>
+     *     {
+     *         "from": (from),
+     *         "to": (to),
+     *         "type": (type),
+     *         "radius": (radius),
+     *         "length": (length),
+     *         "wall": (wall),
+     *         "shear": (shear),
+     *         "stress": (stress),
+     *         "flow": (flow),
+     *     }
+     * </pre>
+     */
     static class SiteEdgeSerializer implements JsonSerializer<SiteEdge> {
         @Override
         public JsonElement serialize(
@@ -198,6 +245,21 @@ public final class PatchOutputSerializer {
         }
     }
 
+    /**
+     * Serializer for {@link SiteNode} objects.
+     *
+     * <p>The object is formatted as:
+     *
+     * <pre>
+     *     {
+     *         "x": (x),
+     *         "y": (y),
+     *         "z": (z),
+     *         "pressure": (pressure),
+     *         "oxygen": (oxygen),
+     *     }
+     * </pre>
+     */
     static class SiteNodeSerializer implements JsonSerializer<SiteNode> {
         @Override
         public JsonElement serialize(

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -233,13 +233,13 @@ public final class PatchOutputSerializer {
 
             json.add("from", context.serialize(src.getFrom()));
             json.add("to", context.serialize(src.getTo()));
-            json.addProperty("type", src.type.toString());
+            json.addProperty("type", src.getType());
             json.addProperty("radius", src.getRadius());
-            json.addProperty("length", src.length);
+            json.addProperty("length", src.getLength());
             json.addProperty("wall", src.getWall());
-            json.addProperty("shear", src.shear);
-            json.addProperty("stress", src.circum);
-            json.addProperty("flow", src.flow);
+            json.addProperty("shear", src.getShear());
+            json.addProperty("stress", src.getCircum());
+            json.addProperty("flow", src.getFlow());
 
             return json;
         }

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -19,6 +19,8 @@ import arcade.patch.env.location.Coordinate;
 import arcade.patch.env.location.CoordinateUVWZ;
 import arcade.patch.env.location.CoordinateXYZ;
 import arcade.patch.env.location.PatchLocationContainer;
+import arcade.patch.env.component.PatchComponentSitesGraph.SiteEdge;
+import arcade.patch.env.component.PatchComponentSitesGraph.SiteNode;
 import arcade.patch.sim.PatchSeries;
 import static arcade.core.sim.Simulation.DEFAULT_LOCATION_TYPE;
 import static arcade.patch.util.PatchEnums.State;
@@ -26,14 +28,18 @@ import static arcade.patch.util.PatchEnums.State;
 /**
  * Container class for patch-specific object serializers.
  *
- * <p>Generic serializers include:
+ * <p>
+ * Generic serializers include:
  *
  * <ul>
- *   <li>{@link PatchSeriesSerializer} for serializing {@link PatchSeries}
- *   <li>{@link PatchCellSerializer} for serializing {@link PatchCellContainer}
- *   <li>{@link LocationListSerializer} for serializing {@link PatchLocationContainer} lists
- *   <li>{@link CoordinateXYZSerializer} for serializing (x, y, z) {@link Coordinate}
- *   <li>{@link CoordinateUVWZSerializer} for serializing (u, v, w, z) {@link Coordinate}
+ * <li>{@link PatchSeriesSerializer} for serializing {@link PatchSeries}
+ * <li>{@link PatchCellSerializer} for serializing {@link PatchCellContainer}
+ * <li>{@link LocationListSerializer} for serializing
+ * {@link PatchLocationContainer} lists
+ * <li>{@link CoordinateXYZSerializer} for serializing (x, y, z)
+ * {@link Coordinate}
+ * <li>{@link CoordinateUVWZSerializer} for serializing (u, v, w, z)
+ * {@link Coordinate}
  * </ul>
  */
 public final class PatchOutputSerializer {
@@ -61,7 +67,9 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link PatchSeries} objects.
      *
-     * <p>The object is first serialized using the generic {@link Series} and patch-specific
+     * <p>
+     * The object is first serialized using the generic {@link Series} and
+     * patch-specific
      * contents are then appended:
      *
      * <pre>
@@ -96,7 +104,8 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CellContainer} objects.
      *
-     * <p>Uses serialization for {@link PatchCellContainer}.
+     * <p>
+     * Uses serialization for {@link PatchCellContainer}.
      */
     static class CellSerializer implements JsonSerializer<CellContainer> {
         @Override
@@ -109,7 +118,8 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link PatchCellContainer} objects.
      *
-     * <p>The container object is formatted as:
+     * <p>
+     * The container object is formatted as:
      *
      * <pre>
      *     {
@@ -151,10 +161,48 @@ public final class PatchOutputSerializer {
         }
     }
 
+    static class SiteEdgeSerializer implements JsonSerializer<SiteEdge> {
+        @Override
+        public JsonElement serialize(
+                SiteEdge src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject json = new JsonObject();
+
+            json.add("from", context.serialize(src.getFrom()));
+            json.add("to", context.serialize(src.getTo()));
+            json.addProperty("type", src.type.toString());
+            json.addProperty("radius", src.getRadius());
+            json.addProperty("length", src.length);
+            json.addProperty("wall", src.getWall());
+            json.addProperty("shear", src.shear);
+            json.addProperty("stress", src.circum);
+            json.addProperty("flow", src.flow);
+
+            return json;
+        }
+    }
+
+    static class SiteNodeSerializer implements JsonSerializer<SiteNode> {
+        @Override
+        public JsonElement serialize(
+                SiteNode src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject json = new JsonObject();
+
+            json.addProperty("x", src.getX());
+            json.addProperty("y", src.getY());
+            json.addProperty("z", src.getZ());
+            json.addProperty("pressure", src.getPressure());
+            json.addProperty("oxygen", src.getOxygen());
+
+            return json;
+        }
+    }
+
     /**
      * Serializer for list of {@link PatchLocationContainer} objects.
      *
-     * <p>This serializer overrides the {@code LocationListSerializer} defined in {@link
+     * <p>
+     * This serializer overrides the {@code LocationListSerializer} defined in
+     * {@link
      * OutputSerializer}. The container object is formatted as:
      *
      * <pre>
@@ -183,8 +231,7 @@ public final class PatchOutputSerializer {
 
             for (LocationContainer locationContainer : src) {
                 PatchLocationContainer container = (PatchLocationContainer) locationContainer;
-                ArrayList<Integer> ids =
-                        containerMap.computeIfAbsent(container.coordinate, k -> new ArrayList<>());
+                ArrayList<Integer> ids = containerMap.computeIfAbsent(container.coordinate, k -> new ArrayList<>());
                 ids.add(container.id);
             }
 
@@ -202,7 +249,8 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CoordinateXYZ} objects.
      *
-     * <p>The coordinate object is formatted as:
+     * <p>
+     * The coordinate object is formatted as:
      *
      * <pre>
      *     [(x), (y), (z)]
@@ -223,7 +271,8 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CoordinateUVWZ} objects.
      *
-     * <p>The coordinate object is formatted as:
+     * <p>
+     * The coordinate object is formatted as:
      *
      * <pre>
      *     [(u), (v), (w), (z)]

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -15,12 +15,12 @@ import arcade.core.env.location.LocationContainer;
 import arcade.core.sim.Series;
 import arcade.core.sim.output.OutputSerializer;
 import arcade.patch.agent.cell.PatchCellContainer;
+import arcade.patch.env.component.PatchComponentSitesGraph.SiteEdge;
+import arcade.patch.env.component.PatchComponentSitesGraph.SiteNode;
 import arcade.patch.env.location.Coordinate;
 import arcade.patch.env.location.CoordinateUVWZ;
 import arcade.patch.env.location.CoordinateXYZ;
 import arcade.patch.env.location.PatchLocationContainer;
-import arcade.patch.env.component.PatchComponentSitesGraph.SiteEdge;
-import arcade.patch.env.component.PatchComponentSitesGraph.SiteNode;
 import arcade.patch.sim.PatchSeries;
 import static arcade.core.sim.Simulation.DEFAULT_LOCATION_TYPE;
 import static arcade.patch.util.PatchEnums.State;
@@ -28,18 +28,14 @@ import static arcade.patch.util.PatchEnums.State;
 /**
  * Container class for patch-specific object serializers.
  *
- * <p>
- * Generic serializers include:
+ * <p>Generic serializers include:
  *
  * <ul>
- * <li>{@link PatchSeriesSerializer} for serializing {@link PatchSeries}
- * <li>{@link PatchCellSerializer} for serializing {@link PatchCellContainer}
- * <li>{@link LocationListSerializer} for serializing
- * {@link PatchLocationContainer} lists
- * <li>{@link CoordinateXYZSerializer} for serializing (x, y, z)
- * {@link Coordinate}
- * <li>{@link CoordinateUVWZSerializer} for serializing (u, v, w, z)
- * {@link Coordinate}
+ *   <li>{@link PatchSeriesSerializer} for serializing {@link PatchSeries}
+ *   <li>{@link PatchCellSerializer} for serializing {@link PatchCellContainer}
+ *   <li>{@link LocationListSerializer} for serializing {@link PatchLocationContainer} lists
+ *   <li>{@link CoordinateXYZSerializer} for serializing (x, y, z) {@link Coordinate}
+ *   <li>{@link CoordinateUVWZSerializer} for serializing (u, v, w, z) {@link Coordinate}
  * </ul>
  */
 public final class PatchOutputSerializer {
@@ -67,9 +63,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link PatchSeries} objects.
      *
-     * <p>
-     * The object is first serialized using the generic {@link Series} and
-     * patch-specific
+     * <p>The object is first serialized using the generic {@link Series} and patch-specific
      * contents are then appended:
      *
      * <pre>
@@ -104,8 +98,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CellContainer} objects.
      *
-     * <p>
-     * Uses serialization for {@link PatchCellContainer}.
+     * <p>Uses serialization for {@link PatchCellContainer}.
      */
     static class CellSerializer implements JsonSerializer<CellContainer> {
         @Override
@@ -118,8 +111,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link PatchCellContainer} objects.
      *
-     * <p>
-     * The container object is formatted as:
+     * <p>The container object is formatted as:
      *
      * <pre>
      *     {
@@ -200,9 +192,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for list of {@link PatchLocationContainer} objects.
      *
-     * <p>
-     * This serializer overrides the {@code LocationListSerializer} defined in
-     * {@link
+     * <p>This serializer overrides the {@code LocationListSerializer} defined in {@link
      * OutputSerializer}. The container object is formatted as:
      *
      * <pre>
@@ -231,7 +221,8 @@ public final class PatchOutputSerializer {
 
             for (LocationContainer locationContainer : src) {
                 PatchLocationContainer container = (PatchLocationContainer) locationContainer;
-                ArrayList<Integer> ids = containerMap.computeIfAbsent(container.coordinate, k -> new ArrayList<>());
+                ArrayList<Integer> ids =
+                        containerMap.computeIfAbsent(container.coordinate, k -> new ArrayList<>());
                 ids.add(container.id);
             }
 
@@ -249,8 +240,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CoordinateXYZ} objects.
      *
-     * <p>
-     * The coordinate object is formatted as:
+     * <p>The coordinate object is formatted as:
      *
      * <pre>
      *     [(x), (y), (z)]
@@ -271,8 +261,7 @@ public final class PatchOutputSerializer {
     /**
      * Serializer for {@link CoordinateUVWZ} objects.
      *
-     * <p>
-     * The coordinate object is formatted as:
+     * <p>The coordinate object is formatted as:
      *
      * <pre>
      *     [(u), (v), (w), (z)]

--- a/src/arcade/potts/sim/PottsSimulation.java
+++ b/src/arcade/potts/sim/PottsSimulation.java
@@ -278,8 +278,7 @@ public abstract class PottsSimulation extends SimState implements Simulation {
             series.saver.schedule(schedule, series.getInterval());
         } else {
             int tick = (int) schedule.getTime() + 1;
-            series.saver.saveCells(tick);
-            series.saver.saveLocations(tick);
+            series.saver.save(tick);
         }
     }
 }

--- a/test/arcade/core/ARCADETest.java
+++ b/test/arcade/core/ARCADETest.java
@@ -38,6 +38,10 @@ public class ARCADETest {
 
         MockARCADE() {}
 
+        MockARCADE(MiniBox parsed) {
+            settings = parsed;
+        }
+
         MockARCADE(Path path) {
             resource = path.toAbsolutePath().toString();
         }
@@ -160,8 +164,8 @@ public class ARCADETest {
         settings.put("SETUP_FILE", SETUP_FILE);
         settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH);
 
-        ARCADE arcade = new MockARCADE();
-        ArrayList<Series> series = arcade.buildSeries(parameters, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        ArrayList<Series> series = arcade.buildSeries(parameters);
 
         assertEquals(1, series.size());
         assertFalse(series.get(0).isVis);
@@ -175,8 +179,8 @@ public class ARCADETest {
         settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH);
         settings.put("VIS", "");
 
-        ARCADE arcade = new MockARCADE();
-        ArrayList<Series> series = arcade.buildSeries(parameters, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        ArrayList<Series> series = arcade.buildSeries(parameters);
 
         assertEquals(1, series.size());
         assertTrue(series.get(0).isVis);
@@ -189,8 +193,8 @@ public class ARCADETest {
         settings.put("SETUP_FILE", SETUP_FILE);
         settings.put("SNAPSHOT_PATH", SNAPSHOT_PATH + "/");
 
-        ARCADE arcade = new MockARCADE();
-        ArrayList<Series> series = arcade.buildSeries(parameters, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        ArrayList<Series> series = arcade.buildSeries(parameters);
 
         assertEquals(1, series.size());
         assertFalse(series.get(0).isVis);
@@ -203,8 +207,8 @@ public class ARCADETest {
 
         MiniBox settings = new MiniBox();
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         verify(series.get(0)).runSims();
         verify(series.get(0), never()).runVis();
@@ -218,8 +222,9 @@ public class ARCADETest {
 
         MiniBox settings = new MiniBox();
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.settings = settings;
+        arcade.runSeries(series);
 
         verify(series.get(0), never()).runSims();
         verify(series.get(0), never()).runVis();
@@ -232,8 +237,9 @@ public class ARCADETest {
 
         MiniBox settings = new MiniBox();
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.settings = settings;
+        arcade.runSeries(series);
 
         verify(series.get(0).saver).saveSeries();
     }
@@ -246,8 +252,9 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("VIS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.settings = settings;
+        arcade.runSeries(series);
 
         verify(series.get(0), never()).runSims();
         verify(series.get(0)).runVis();
@@ -262,8 +269,9 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("VIS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.settings = settings;
+        arcade.runSeries(series);
 
         verify(series.get(0), never()).runSims();
         verify(series.get(0), never()).runVis();
@@ -277,8 +285,9 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("VIS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.settings = settings;
+        arcade.runSeries(series);
 
         assertNull(series.get(0).saver);
     }
@@ -293,8 +302,8 @@ public class ARCADETest {
 
         MiniBox settings = new MiniBox();
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         for (int i = 0; i < n; i++) {
             verify(series.get(i)).runSims();
@@ -312,8 +321,8 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("VIS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         verify(series.get(0)).runVis();
         for (int i = 1; i < n; i++) {
@@ -329,8 +338,8 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("LOAD_CELLS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         assertTrue(series.get(0).loader.loadCells);
         assertFalse(series.get(0).loader.loadLocations);
@@ -344,8 +353,8 @@ public class ARCADETest {
         MiniBox settings = new MiniBox();
         settings.put("LOAD_LOCATIONS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         assertFalse(series.get(0).loader.loadCells);
         assertTrue(series.get(0).loader.loadLocations);
@@ -360,8 +369,8 @@ public class ARCADETest {
         settings.put("LOAD_CELLS", "");
         settings.put("LOAD_LOCATIONS", "");
 
-        ARCADE arcade = new MockARCADE();
-        arcade.runSeries(series, settings);
+        ARCADE arcade = new MockARCADE(settings);
+        arcade.runSeries(series);
 
         assertTrue(series.get(0).loader.loadCells);
         assertTrue(series.get(0).loader.loadLocations);

--- a/test/arcade/patch/PatchARCADETest.java
+++ b/test/arcade/patch/PatchARCADETest.java
@@ -99,7 +99,7 @@ public class PatchARCADETest {
 
     @Test
     public void getSaver_called_returnsBuilder() {
-        PatchARCADE arcade = new PatchARCADE();
+        PatchARCADE arcade = spy(new PatchARCADE());
         assertTrue(arcade.getSaver(mock(Series.class)) instanceof PatchOutputSaver);
     }
 }

--- a/test/arcade/potts/sim/PottsSimulationTest.java
+++ b/test/arcade/potts/sim/PottsSimulationTest.java
@@ -632,8 +632,7 @@ public class PottsSimulationTest {
 
         sim.doOutput(true);
         verify(saver).schedule(schedule, interval);
-        verify(saver, never()).saveCells(anyInt());
-        verify(saver, never()).saveLocations(anyInt());
+        verify(saver, never()).save(anyInt());
     }
 
     @Test
@@ -651,7 +650,6 @@ public class PottsSimulationTest {
 
         sim.doOutput(false);
         verify(saver, never()).schedule(eq(schedule), anyDouble());
-        verify(saver).saveCells((int) time + 1);
-        verify(saver).saveLocations((int) time + 1);
+        verify(saver).save((int) time + 1);
     }
 }


### PR DESCRIPTION
Estimated size: _Large_

Updating ARCADE to output graph files for each of the `SitesGraph`s that may be in the simulation. They are saved to the following:

`{PREFIX}.{Component ID}.GRAPH.json` 

to store graphs in the form of: 

```json
[
 {
    "from": {
      "x": 2,
      "y": 18,
      "z": 0,
      "pressure": 33.2461815231151,
      "oxygen": 64.59963917732239
    },
    "to": {
      "x": 4,
      "y": 20,
      "z": 0,
      "pressure": 32.89741610570517,
      "oxygen": 64.59543108940125
    },
    "type": "VEIN",
    "radius": 5.616233810895305,
    "length": 34.64101615137755,
    "wall": 2.0079168698337506,
    "shear": 0.028272093993564406,
    "stress": 92.50330901597339,
    "flow": 4976410.979431053
  },
  {
    "from": {
      "x": 4,
      "y": 4,
      "z": 0,
      "pressure": 41.48210888517919,
      "oxygen": 64.72212019180989
    },
    "to": {
      "x": 8,
      "y": 4,
      "z": 0,
      "pressure": 41.26865240481092,
      "oxygen": 64.72200751304626
    },
    "type": "ARTERY",
    "radius": 9.722120191809886,
    "length": 34.64101615137755,
    "wall": 3.086609003958372,
    "shear": 0.029953647271667213,
    "stress": 130.3230901927193,
    "flow": 4.366536325306217E7
  },
  ...
]
```

This can be accomplished by running ARCADE by using: 

```bash 
$ java -jar ARCADE-X.X.X.jar patch path/to/input/ path/to/output --graph
``` 

Other major changes:

Command line commands are now attached to the ARCADE object as settings for accessibility at lower levels of abstraction.