### PR TITLE
Added docstrings to enums to reduce linter errors.

### DIFF
--- a/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
@@ -28,9 +28,16 @@ import static arcade.patch.env.component.PatchComponentSitesGraphUtilities.*;
 public abstract class PatchComponentSitesGraphFactory {
     /** Border directions. */
     enum Border {
+        /** Code for left (+x) border. */
         LEFT,
+		
+	/** Code for right (-x) border. */
         RIGHT,
+
+	/** Code for top (-y) border. */
         TOP,
+
+	/** Code for bottom (+y) border. */
         BOTTOM
     }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraphFactory.java
@@ -30,14 +30,14 @@ public abstract class PatchComponentSitesGraphFactory {
     enum Border {
         /** Code for left (+x) border. */
         LEFT,
-		
-	/** Code for right (-x) border. */
+
+        /** Code for right (-x) border. */
         RIGHT,
 
-	/** Code for top (-y) border. */
+        /** Code for top (-y) border. */
         TOP,
 
-	/** Code for bottom (+y) border. */
+        /** Code for bottom (+y) border. */
         BOTTOM
     }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesPattern.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesPattern.java
@@ -28,11 +28,22 @@ import arcade.core.util.MiniBox;
 public abstract class PatchComponentSitesPattern extends PatchComponentSites {
     /** Border directions. */
     enum Border {
+        /** Code for left (+x) border. */
         LEFT,
+		
+	/** Code for right (-x) border. */
         RIGHT,
+
+	/** Code for top (-y) border. */
         TOP,
-        BOTTOM,
+
+	/** Code for bottom (+y) border. */
+        BOTTOM, 
+
+	/** Code for upper (+z) border. */
         UP,
+
+	/** Code for downward (-z) border. */
         DOWN
     }
 

--- a/src/arcade/patch/env/component/PatchComponentSitesPattern.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesPattern.java
@@ -30,20 +30,20 @@ public abstract class PatchComponentSitesPattern extends PatchComponentSites {
     enum Border {
         /** Code for left (+x) border. */
         LEFT,
-		
-	/** Code for right (-x) border. */
+
+        /** Code for right (-x) border. */
         RIGHT,
 
-	/** Code for top (-y) border. */
+        /** Code for top (-y) border. */
         TOP,
 
-	/** Code for bottom (+y) border. */
-        BOTTOM, 
+        /** Code for bottom (+y) border. */
+        BOTTOM,
 
-	/** Code for upper (+z) border. */
+        /** Code for upper (+z) border. */
         UP,
 
-	/** Code for downward (-z) border. */
+        /** Code for downward (-z) border. */
         DOWN
     }
 

--- a/src/arcade/patch/vis/PatchDrawer.java
+++ b/src/arcade/patch/vis/PatchDrawer.java
@@ -45,20 +45,40 @@ public abstract class PatchDrawer extends Drawer {
 
     /** View options for cells. */
     enum CellView {
+        /** Code for encoding visualization by agent state.  */
         STATE,
+
+        /** Code for encoding visualization by agent age.  */
         AGE,
+
+        /** Code for encoding visualization by agent volume.  */
         VOLUME,
+
+        /** Code for encoding visualization by agent height.  */
         HEIGHT,
+
+        /** Code for encoding visualization by agent counts.  */
         COUNTS,
+
+        /** Code for encoding visualization by agent population.  */
         POPULATION,
+
+        /** Code for encoding visualization by agent energy.  */
         ENERGY,
+
+        /** Code for encoding visualization by agent divisions.  */
         DIVISIONS
     }
 
     /** View options for lattices. */
     enum LatticeView {
+        /** Code for encoding visualization by lattice concentrations.  */
         CONCENTRATION,
+
+        /** Code for encoding visualization by component sites.  */
         SITES,
+
+        /** Code for encoding visualization by component damage.  */
         DAMAGE
     }
 

--- a/src/arcade/patch/vis/PatchDrawer.java
+++ b/src/arcade/patch/vis/PatchDrawer.java
@@ -45,40 +45,40 @@ public abstract class PatchDrawer extends Drawer {
 
     /** View options for cells. */
     enum CellView {
-        /** Code for encoding visualization by agent state.  */
+        /** Code for encoding visualization by agent state. */
         STATE,
 
-        /** Code for encoding visualization by agent age.  */
+        /** Code for encoding visualization by agent age. */
         AGE,
 
-        /** Code for encoding visualization by agent volume.  */
+        /** Code for encoding visualization by agent volume. */
         VOLUME,
 
-        /** Code for encoding visualization by agent height.  */
+        /** Code for encoding visualization by agent height. */
         HEIGHT,
 
-        /** Code for encoding visualization by agent counts.  */
+        /** Code for encoding visualization by agent counts. */
         COUNTS,
 
-        /** Code for encoding visualization by agent population.  */
+        /** Code for encoding visualization by agent population. */
         POPULATION,
 
-        /** Code for encoding visualization by agent energy.  */
+        /** Code for encoding visualization by agent energy. */
         ENERGY,
 
-        /** Code for encoding visualization by agent divisions.  */
+        /** Code for encoding visualization by agent divisions. */
         DIVISIONS
     }
 
     /** View options for lattices. */
     enum LatticeView {
-        /** Code for encoding visualization by lattice concentrations.  */
+        /** Code for encoding visualization by lattice concentrations. */
         CONCENTRATION,
 
-        /** Code for encoding visualization by component sites.  */
+        /** Code for encoding visualization by component sites. */
         SITES,
 
-        /** Code for encoding visualization by component damage.  */
+        /** Code for encoding visualization by component damage. */
         DAMAGE
     }
 

--- a/src/arcade/potts/vis/PottsDrawer.java
+++ b/src/arcade/potts/vis/PottsDrawer.java
@@ -38,7 +38,7 @@ public abstract class PottsDrawer extends Drawer {
 
     /** Planes for visualization. */
     enum Plane {
-        /** Code for Z plane. */ 
+        /** Code for Z plane. */
         Z,
 
         /** Code for X plane. */

--- a/src/arcade/potts/vis/PottsDrawer.java
+++ b/src/arcade/potts/vis/PottsDrawer.java
@@ -38,19 +38,37 @@ public abstract class PottsDrawer extends Drawer {
 
     /** Planes for visualization. */
     enum Plane {
+        /** Code for Z plane. */ 
         Z,
+
+        /** Code for X plane. */
         X,
+
+        /** Code for Y plane. */
         Y
     }
 
     /** View options. */
     enum View {
+        /** Code for encoding visualization by cytoplasm. */
         CYTOPLASM,
+
+        /** Code for encoding visualization by nucleus. */
         NUCLEUS,
+
+        /** Code for encoding visualization by region overlay. */
         OVERLAY,
+
+        /** Code for encoding visualization by state. */
         STATE,
+
+        /** Code for encoding visualization by population. */
         POPULATION,
+
+        /** Code for encoding visualization by volume. */
         VOLUME,
+
+        /** Code for encoding visualization by height. */
         HEIGHT
     }
 


### PR DESCRIPTION
Linter was flagging enums without docstrings, so I added them. 

Size: _small_.