### PR TITLE
Add simple sensing for VEGF secretion.

### DIFF
--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -27,6 +27,7 @@ import arcade.patch.agent.module.PatchModuleSenescence;
 import arcade.patch.agent.module.PatchModuleStimulation;
 import arcade.patch.agent.process.PatchProcessInflammation;
 import arcade.patch.agent.process.PatchProcessMetabolism;
+import arcade.patch.agent.process.PatchProcessSensing;
 import arcade.patch.agent.process.PatchProcessSignaling;
 import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.location.PatchLocation;
@@ -384,6 +385,8 @@ public abstract class PatchCell implements Cell {
                 return PatchProcessSignaling.make(this, version);
             case INFLAMMATION:
                 return PatchProcessInflammation.make(this, version);
+            case SENSING:
+                return PatchProcessSensing.make(this, version);
             case UNDEFINED:
             default:
                 return null;

--- a/src/arcade/patch/agent/process/PatchProcessMetabolism.java
+++ b/src/arcade/patch/agent/process/PatchProcessMetabolism.java
@@ -10,7 +10,7 @@ import arcade.patch.env.grid.PatchGrid;
 import static arcade.patch.util.PatchEnums.State;
 
 /**
- * Implementation of {@link Process} for cell metabolism.
+ * Abstract implementation of {@link Process} for cell metabolism.
  *
  * <p>The {@code PatchProcessMetabolism} process:
  *

--- a/src/arcade/patch/agent/process/PatchProcessSensing.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensing.java
@@ -9,9 +9,6 @@ import arcade.patch.agent.cell.PatchCell;
  * based on cell state or environmental conditions.
  */
 public abstract class PatchProcessSensing extends PatchProcess {
-    /** Step size for process [sec]. */
-    static final double STEP_SIZE = 1.0;
-
     /**
      * Creates a signaling {@link PatchProcessSensing} for the given cell.
      *

--- a/src/arcade/patch/agent/process/PatchProcessSensing.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensing.java
@@ -1,0 +1,39 @@
+package arcade.patch.agent.process;
+
+import arcade.patch.agent.cell.PatchCell;
+
+/**
+ * Abstract implementation of {@link Process} for {@link PatchCell} sensing.
+ *
+ * <p>The {@code PatchProcessSensing} process can be used for adding molecules to the environment
+ * based on cell state or environmental conditions.
+ */
+public abstract class PatchProcessSensing extends PatchProcess {
+    /** Step size for process [sec]. */
+    static final double STEP_SIZE = 1.0;
+
+    /**
+     * Creates a signaling {@link PatchProcess} for the given cell.
+     *
+     * @param cell the {@link PatchCell} the process is associated with
+     */
+    PatchProcessSensing(PatchCell cell) {
+        super(cell);
+    }
+
+    /**
+     * Creates a {@code PatchProcessSignaling} for given version.
+     *
+     * @param cell the {@link PatchCell} the process is associated with
+     * @param version the process version
+     * @return the process instance
+     */
+    public static PatchProcess make(PatchCell cell, String version) {
+        switch (version.toUpperCase()) {
+            case "SIMPLE":
+                return new PatchProcessSignalingRandom(cell);
+            default:
+                return null;
+        }
+    }
+}

--- a/src/arcade/patch/agent/process/PatchProcessSensing.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensing.java
@@ -13,7 +13,7 @@ public abstract class PatchProcessSensing extends PatchProcess {
     static final double STEP_SIZE = 1.0;
 
     /**
-     * Creates a signaling {@link PatchProcess} for the given cell.
+     * Creates a signaling {@link PatchProcessSensing} for the given cell.
      *
      * @param cell the {@link PatchCell} the process is associated with
      */

--- a/src/arcade/patch/agent/process/PatchProcessSensing.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensing.java
@@ -31,7 +31,7 @@ public abstract class PatchProcessSensing extends PatchProcess {
     public static PatchProcess make(PatchCell cell, String version) {
         switch (version.toUpperCase()) {
             case "SIMPLE":
-                return new PatchProcessSignalingRandom(cell);
+                return new PatchProcessSensingSimple(cell);
             default:
                 return null;
         }

--- a/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
@@ -39,8 +39,8 @@ public class PatchProcessSensingSimple extends PatchProcessSensing {
     @Override
     public void step(MersenneTwisterFast random, Simulation sim) {
         if (cell.getEnergy() < 0) {
-            Double VEGF = sim.getLattice("VEGF").getAverageValue(location);
-            Double newVEGF = VEGF + secretionRate;
+            Double currVEGF = sim.getLattice("VEGF").getAverageValue(location);
+            Double newVEGF = currVEGF + secretionRate;
             sim.getLattice("VEGF").setValue(location, newVEGF);
         }
     }

--- a/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
@@ -39,8 +39,8 @@ public class PatchProcessSensingSimple extends PatchProcessSensing {
     @Override
     public void step(MersenneTwisterFast random, Simulation sim) {
         if (cell.getEnergy() < 0) {
-            Double currVEGF = sim.getLattice("VEGF").getAverageValue(location);
-            Double newVEGF = currVEGF + secretionRate;
+            double currVEGF = sim.getLattice("VEGF").getAverageValue(location);
+            double newVEGF = currVEGF + secretionRate;
             sim.getLattice("VEGF").setValue(location, newVEGF);
         }
     }

--- a/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
@@ -1,0 +1,50 @@
+package arcade.patch.agent.process;
+
+import ec.util.MersenneTwisterFast;
+import arcade.core.agent.process.Process;
+import arcade.core.sim.Simulation;
+import arcade.patch.agent.cell.PatchCell;
+
+/**
+ * Extension of {@link PatchProcessSensing} for simple sensing.
+ *
+ * <p>The {@code PatchProcessSensingSimple} process adds VEGF to the environment, based on the
+ * energy level of the cell. If a cell's energy is below 0 (energy-deficient and quiescent), VEGF is
+ * added to the environment at the rate specified by the input parameter SECRETION_RATE.
+ */
+public class PatchProcessSensingSimple extends PatchProcessSensing {
+
+    /** Rate of secretion of VEGF [VEGF/min]. */
+    private final double secretionRate;
+
+    /**
+     * Creates a simple sensing {@code Process} for the given {@link PatchCell}. Sensing modules add
+     * VEGF to the environment, based on the energy level of the cell or the environmental
+     * conditions.
+     *
+     * <p>Loaded parameters include:
+     *
+     * <ul>
+     *   <li>{@code SECRETION_RATE} = rate of secretion of VEGF
+     * </ul>
+     *
+     * @param cell the {@link PatchCell} the process is associated with
+     */
+    public PatchProcessSensingSimple(PatchCell cell) {
+        super(cell);
+
+        secretionRate = cell.getParameters().getDouble("sensing/VEGF_SECRETION_RATE");
+    }
+
+    @Override
+    public void step(MersenneTwisterFast random, Simulation sim) {
+        if (cell.getEnergy() < 0) {
+            Double VEGF = sim.getLattice("VEGF").getAverageValue(location);
+            Double newVEGF = VEGF + secretionRate;
+            sim.getLattice("VEGF").setValue(location, newVEGF);
+        }
+    }
+
+    @Override
+    public void update(Process process) {}
+}

--- a/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
+++ b/src/arcade/patch/agent/process/PatchProcessSensingSimple.java
@@ -10,7 +10,7 @@ import arcade.patch.agent.cell.PatchCell;
  *
  * <p>The {@code PatchProcessSensingSimple} process adds VEGF to the environment, based on the
  * energy level of the cell. If a cell's energy is below 0 (energy-deficient and quiescent), VEGF is
- * added to the environment at the rate specified by the input parameter SECRETION_RATE.
+ * added to the environment at the rate specified by the input parameter VEGF_SECRETION_RATE.
  */
 public class PatchProcessSensingSimple extends PatchProcessSensing {
 
@@ -25,7 +25,7 @@ public class PatchProcessSensingSimple extends PatchProcessSensing {
      * <p>Loaded parameters include:
      *
      * <ul>
-     *   <li>{@code SECRETION_RATE} = rate of secretion of VEGF
+     *   <li>{@code VEGF_SECRETION_RATE} = rate of secretion of VEGF
      * </ul>
      *
      * @param cell the {@link PatchCell} the process is associated with

--- a/src/arcade/patch/agent/process/PatchProcessSignaling.java
+++ b/src/arcade/patch/agent/process/PatchProcessSignaling.java
@@ -4,7 +4,7 @@ import java.util.List;
 import arcade.patch.agent.cell.PatchCell;
 
 /**
- * Implementation of {@link Process} for cell metabolism.
+ * Abstract implementation of {@link Process} for cell signaling.
  *
  * <p>The {@code PatchProcessSignaling} process can be used for networks comprising a system of
  * ODEs.

--- a/src/arcade/patch/parameter.patch.xml
+++ b/src/arcade/patch/parameter.patch.xml
@@ -93,6 +93,9 @@
     <!-- inflammation CD8 module -->
     <population.process process="inflammation" id="GRANZ_SYNTHESIS_DELAY" value="15" unit="min" description="Time required for CAR T-cells to maintain bound contact with target antigen before activation signal induces granzyme production"/>
 
+    <!-- metabolism process parameters -->
+    <population.process process="sensing" id="VEGF_SECRETION_RATE" value="100" unit="pg/ml/min" description="secretion rate of VEGF" />
+
     <!-- LAYERS ============================================================ -->
 
     <!-- default parameters for layers -->

--- a/src/arcade/patch/util/PatchEnums.java
+++ b/src/arcade/patch/util/PatchEnums.java
@@ -136,7 +136,7 @@ public final class PatchEnums {
         /** Code for signaling domain. */
         SIGNALING,
 
-        /** COde for sensing domain. */
+        /** Code for sensing domain. */
         SENSING;
 
         /**

--- a/src/arcade/patch/util/PatchEnums.java
+++ b/src/arcade/patch/util/PatchEnums.java
@@ -134,7 +134,10 @@ public final class PatchEnums {
         INFLAMMATION,
 
         /** Code for signaling domain. */
-        SIGNALING;
+        SIGNALING,
+
+        /** COde for sensing domain. */
+        SENSING;
 
         /**
          * Randomly selects a {@code Domain}.

--- a/test/arcade/patch/agent/process/PatchProcessSensingSimpleTest.java
+++ b/test/arcade/patch/agent/process/PatchProcessSensingSimpleTest.java
@@ -1,0 +1,70 @@
+package arcade.patch.agent.process;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import ec.util.MersenneTwisterFast;
+import arcade.core.util.Parameters;
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.env.lattice.PatchLattice;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import static org.mockito.Mockito.*;
+import static arcade.core.ARCADETestUtilities.*;
+
+public class PatchProcessSensingSimpleTest {
+
+    static PatchCell cellMock;
+
+    static PatchSimulation simMock;
+
+    static MersenneTwisterFast randomMock;
+
+    static Parameters parametersMock;
+
+    static PatchLocation locationMock;
+
+    static PatchLattice latticeMock;
+
+    @BeforeAll
+    public static void setupMocks() {
+        cellMock = mock(PatchCell.class);
+        simMock = mock(PatchSimulation.class);
+        randomMock = mock(MersenneTwisterFast.class);
+        parametersMock = mock(Parameters.class);
+        locationMock = mock(PatchLocation.class);
+        doReturn(parametersMock).when(cellMock).getParameters();
+        doReturn(locationMock).when(cellMock).getLocation();
+        latticeMock = mock(PatchLattice.class);
+        doReturn(latticeMock).when(simMock).getLattice("VEGF");
+    }
+
+    @Test
+    public void step_calledWithNegativeEnergyCell_updatesLattice() {
+        double energy = randomDoubleBetween(-100, -0.1);
+        double secretionRate = randomDoubleBetween(1, 100);
+        double currentVEGF = randomDoubleBetween(0, 100);
+        doReturn(energy).when(cellMock).getEnergy();
+        doReturn(secretionRate).when(parametersMock).getDouble("sensing/VEGF_SECRETION_RATE");
+        doReturn(currentVEGF).when(latticeMock).getAverageValue(locationMock);
+
+        PatchProcessSensingSimple sensing = new PatchProcessSensingSimple(cellMock);
+        sensing.step(randomMock, simMock);
+
+        verify(latticeMock).setValue(locationMock, currentVEGF + secretionRate);
+    }
+
+    @Test
+    public void step_calledWithPositiveEnergyCell_doesNotUpdateLattice() {
+        double energy = randomDoubleBetween(0.1, 100);
+        double secretionRate = randomDoubleBetween(1, 100);
+        double currentVEGF = randomDoubleBetween(0, 100);
+        doReturn(energy).when(cellMock).getEnergy();
+        doReturn(secretionRate).when(parametersMock).getDouble("sensing/VEGF_SECRETION_RATE");
+        doReturn(currentVEGF).when(latticeMock).getAverageValue(locationMock);
+
+        PatchProcessSensingSimple sensing = new PatchProcessSensingSimple(cellMock);
+        sensing.step(randomMock, simMock);
+
+        verify(latticeMock, never()).setValue(locationMock, currentVEGF + secretionRate);
+    }
+}


### PR DESCRIPTION
Added `PatchProcess` to secrete VEGF when a cell is energy deficient. Some bonus documentation changes.

Estimated size: _small_. 

Example input:
```xml
                <population id="cancerous" init="2" class="cancer">
                    <population.process id="METABOLISM" version="complex"/>
                    <population.process id="SIGNALING" version="complex"/>
                    <population.process id="SENSING" version="simple" />
                    <population.parameter id="VEGF_SECRETION_RATE" process="sensing" scale="100" />
                    <population.parameter id="COMPRESSION_TOLERANCE" value="4.35"/>
                    <population.parameter id="METABOLIC_PREFERENCE" process="metabolism" scale="1.5" />
                    <population.parameter id="MIGRATORY_THRESHOLD" scale="0.5" />
                    <population.parameter id="CAR_ANTIGENS_CANCER" value="1000" />
                </population>
```

