### PR TITLE
Updating Graph Output for arcade-visualization

### DIFF
--- a/src/arcade/patch/env/component/PatchComponentSitesGraph.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraph.java
@@ -605,6 +605,22 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         public double getFlow() {
             return flow;
         }
+
+        public String getFraction() {
+            StringBuilder sb = new StringBuilder();
+            for (String key : fraction.keySet()) {
+                sb.append(key + ":" + fraction.get(key) + ",");
+            }
+            return sb.toString();
+        }
+
+        public String getTransport() {
+            StringBuilder sb = new StringBuilder();
+            for (String key : transport.keySet()) {
+                sb.append(key + ":" + transport.get(key) + ",");
+            }
+            return sb.toString();
+        }
     }
 
     /**

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -254,6 +254,7 @@ public final class PatchOutputSerializer {
             return json;
         }
     }
+
     /**
      * Serializer for {@link SiteNode} objects.
      *

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -248,8 +248,6 @@ public final class PatchOutputSerializer {
             json.addProperty("shear", src.getShear());
             json.addProperty("stress", src.getCircum());
             json.addProperty("flow", src.getFlow());
-            json.addProperty("fraction", src.getFraction());
-            json.addProperty("transport", src.getTransport());
 
             return json;
         }

--- a/src/arcade/patch/sim/output/PatchOutputSerializer.java
+++ b/src/arcade/patch/sim/output/PatchOutputSerializer.java
@@ -220,12 +220,15 @@ public final class PatchOutputSerializer {
      *         "from": (from),
      *         "to": (to),
      *         "type": (type),
+     *         "sign": (sign),
      *         "radius": (radius),
      *         "length": (length),
      *         "wall": (wall),
      *         "shear": (shear),
      *         "stress": (stress),
      *         "flow": (flow),
+     *         "fraction": (fraction),
+     *         "transport": (transport),
      *     }
      * </pre>
      */
@@ -238,17 +241,19 @@ public final class PatchOutputSerializer {
             json.add("from", context.serialize(src.getFrom()));
             json.add("to", context.serialize(src.getTo()));
             json.addProperty("type", src.getType());
+            json.addProperty("sign", src.getSign());
             json.addProperty("radius", src.getRadius());
             json.addProperty("length", src.getLength());
             json.addProperty("wall", src.getWall());
             json.addProperty("shear", src.getShear());
             json.addProperty("stress", src.getCircum());
             json.addProperty("flow", src.getFlow());
+            json.addProperty("fraction", src.getFraction());
+            json.addProperty("transport", src.getTransport());
 
             return json;
         }
     }
-
     /**
      * Serializer for {@link SiteNode} objects.
      *


### PR DESCRIPTION
Updated PatchOutputSerializer to output SITES.GRAPH.json files in this format:

>   {
>     "from": {
>       "x": 10,
>       "y": 30,
>       "z": 0,
>       "pressure": 56.99829015221532,
>       "oxygen": 79.47211936116219
>     },
>     "to": {
>       "x": 12,
>       "y": 28,
>       "z": 0,
>       "pressure": 56.93131181220028,
>       "oxygen": 79.47211638092995
>     },
>     "type": "ARTERY",
>     "sign": -1,
>     "radius": 24.412305860254712,
>     "length": 34.64101615137755,
>     "wall": 6.110612101951247,
>     "shear": 0.02360057388781724,
>     "stress": 227.5782068382533,
>     "flow": 7.882493452400926E8,
>     "fraction": "GLUCOSE:0.9999999877956426,",
>     "transport": "OXYGEN:-1.446155143779032,GLUCOSE:0.0,"
>   }

Size: xsmall

Summary:
Added sign, fraction, and transport fields to the SiteEdge serializer
Added the SiteEdge `getFraction()` and `getTransport()` functions from angiogenesis branch
