### PR TITLE
Fixing inconsistent interval results 

### DIFF
--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -45,6 +45,9 @@ public abstract class OutputSaver implements Steppable {
     /** {@link arcade.core.sim.Simulation} instance. */
     protected Simulation sim;
 
+    /** Snapshot interval in ticks. */
+    private final int interval;
+
     /**
      * Creates an {@code OutputSaver} for the series.
      *
@@ -53,6 +56,7 @@ public abstract class OutputSaver implements Steppable {
     public OutputSaver(Series series) {
         this.series = series;
         this.gson = makeGSON();
+        this.interval = series.getInterval();
     }
 
     /**
@@ -109,7 +113,9 @@ public abstract class OutputSaver implements Steppable {
     @Override
     public void step(SimState simstate) {
         int tick = (int) simstate.schedule.getTime();
-        save(tick);
+        if (tick % interval == 0) {
+            save(tick);
+        }
     }
 
     /**

--- a/src/arcade/core/sim/output/OutputSaver.java
+++ b/src/arcade/core/sim/output/OutputSaver.java
@@ -128,8 +128,8 @@ public abstract class OutputSaver implements Steppable {
      * @param schedule the simulation schedule
      * @param interval the interval (in ticks) between snapshots
      */
-    public void schedule(Schedule schedule, double interval) {
-        schedule.scheduleRepeating(Schedule.EPOCH, -1, this, interval);
+    public void schedule(Schedule schedule) {
+        schedule.scheduleRepeating(Schedule.EPOCH, -1, this, 1);
     }
 
     /**

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -418,7 +418,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
      */
     public void doOutput(boolean isScheduled) {
         if (isScheduled) {
-            series.saver.schedule(schedule, series.getInterval());
+            series.saver.schedule(schedule);
         } else {
             int tick = (int) schedule.getTime() + 1;
             series.saver.save(tick);

--- a/src/arcade/potts/sim/PottsSimulation.java
+++ b/src/arcade/potts/sim/PottsSimulation.java
@@ -275,7 +275,7 @@ public abstract class PottsSimulation extends SimState implements Simulation {
      */
     public void doOutput(boolean isScheduled) {
         if (isScheduled) {
-            series.saver.schedule(schedule, series.getInterval());
+            series.saver.schedule(schedule);
         } else {
             int tick = (int) schedule.getTime() + 1;
             series.saver.save(tick);

--- a/test/arcade/core/sim/output/OutputSaverTest.java
+++ b/test/arcade/core/sim/output/OutputSaverTest.java
@@ -213,9 +213,8 @@ public class OutputSaverTest {
         Schedule schedule = mock(Schedule.class);
         OutputSaver saver = mock(OutputSaver.class, CALLS_REAL_METHODS);
         doReturn(null).when(schedule).scheduleRepeating(anyDouble(), anyInt(), any(), anyDouble());
-        double interval = randomDoubleBetween(1, 10);
-        saver.schedule(schedule, interval);
-        verify(schedule).scheduleRepeating(Schedule.EPOCH, -1, saver, interval);
+        saver.schedule(schedule);
+        verify(schedule).scheduleRepeating(Schedule.EPOCH, -1, saver);
     }
 
     @Test

--- a/test/arcade/core/sim/output/OutputSaverTest.java
+++ b/test/arcade/core/sim/output/OutputSaverTest.java
@@ -191,15 +191,21 @@ public class OutputSaverTest {
     }
 
     @Test
-    public void step_singleStep_callsSave() {
-        OutputSaver saver = mock(OutputSaver.class, CALLS_REAL_METHODS);
+    public void step_atIntervalTick_callsSave() {
+        Series series = mock(Series.class);
+        int interval = randomIntBetween(1, 100);
+        doReturn(interval).when(series).getInterval();
+
+        OutputSaver saver = spy(new OutputSaverMock(series));
         doNothing().when(saver).saveCells(anyInt());
         doNothing().when(saver).saveLocations(anyInt());
 
         SimState simstate = mock(SimState.class);
         simstate.schedule = mock(Schedule.class);
-        int tick = randomIntBetween(1, 100);
-        doReturn((double) tick).when(simstate.schedule).getTime();
+       
+        int tick = randomIntBetween(1, 10) * interval;
+        
+        doReturn((double) tick).when(simstate.schedule).getTime();        
 
         saver.prefix = randomString();
 
@@ -214,7 +220,7 @@ public class OutputSaverTest {
         OutputSaver saver = mock(OutputSaver.class, CALLS_REAL_METHODS);
         doReturn(null).when(schedule).scheduleRepeating(anyDouble(), anyInt(), any(), anyDouble());
         saver.schedule(schedule);
-        verify(schedule).scheduleRepeating(Schedule.EPOCH, -1, saver);
+        verify(schedule).scheduleRepeating(Schedule.EPOCH, -1, saver, 1);
     }
 
     @Test

--- a/test/arcade/potts/sim/PottsSimulationTest.java
+++ b/test/arcade/potts/sim/PottsSimulationTest.java
@@ -631,7 +631,7 @@ public class PottsSimulationTest {
         doReturn(interval).when(series).getInterval();
 
         sim.doOutput(true);
-        verify(saver).schedule(schedule, interval);
+        verify(saver).schedule(schedule);
         verify(saver, never()).save(anyInt());
     }
 
@@ -649,7 +649,7 @@ public class PottsSimulationTest {
         doReturn(time).when(sim.schedule).getTime();
 
         sim.doOutput(false);
-        verify(saver, never()).schedule(eq(schedule), anyDouble());
+        verify(saver, never()).schedule(eq(schedule));
         verify(saver).save((int) time + 1);
     }
 }


### PR DESCRIPTION
Size: Small

There was an issue where changing the series interval changed the output files. To fix this, interval had to be removed from the saver schedule.

Here are the changes:
1. Removed `interval` from the OutputSaver.schedule() method and updated everywhere that called this.
2. Added a private interval field to OutputSaver and set it to series.getInterval()
3. Updated step to only call save() if tick % interval == 0
4. Wrote a test to check that save() is only called when tick % interval == 0