### PR TITLE
Add event logging

### DIFF
--- a/src/arcade/patch/PatchARCADE.java
+++ b/src/arcade/patch/PatchARCADE.java
@@ -34,6 +34,7 @@ public final class PatchARCADE extends ARCADE {
         PatchOutputSaver saver = new PatchOutputSaver(series);
         saver.saveGraph = settings.contains("SAVE_GRAPH");
         saver.saveLattice = settings.contains("SAVE_LAYERS");
+        saver.saveEvents = settings.contains("SAVE_EVENTS");
         return saver;
     }
 }

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -1,5 +1,7 @@
 package arcade.patch.agent.module;
 
+import java.util.HashMap;
+import java.util.Map;
 import ec.util.MersenneTwisterFast;
 import arcade.core.sim.Simulation;
 import arcade.core.util.Parameters;
@@ -7,6 +9,8 @@ import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
 import static arcade.patch.util.PatchEnums.Domain;
 import static arcade.patch.util.PatchEnums.State;
 
@@ -68,6 +72,18 @@ public class PatchModuleCytotoxicity extends PatchModule {
                 tissueCell.setState(State.APOPTOTIC);
                 granzyme--;
                 inflammation.setInternal("granzyme", granzyme);
+
+                // Log cytotoxicity event
+                PatchSimulation patchSim = (PatchSimulation) sim;
+                Map<String, Object> eventData = new HashMap<>();
+                eventData.put("t-cell-id", cell.getID());
+                eventData.put("tissue-cell-id", target.getID());
+                eventData.put("tissue-cell-type", target.getPop());
+                eventData.put("type", "lysis");
+                eventData.put("timestamp", (int) ((PatchSimulation) sim).getSchedule().getTime());
+                eventData.put(
+                        "tissue-location", ((PatchLocation) target.getLocation()).getCoordinate());
+                patchSim.logEvent(eventData);
             }
         }
 

--- a/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
+++ b/src/arcade/patch/agent/module/PatchModuleCytotoxicity.java
@@ -11,6 +11,8 @@ import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.agent.process.PatchProcessInflammation;
 import arcade.patch.env.location.PatchLocation;
 import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.Domain;
+import arcade.patch.util.PatchEnums.State;
 import static arcade.patch.util.PatchEnums.Domain;
 import static arcade.patch.util.PatchEnums.State;
 
@@ -76,13 +78,14 @@ public class PatchModuleCytotoxicity extends PatchModule {
                 // Log cytotoxicity event
                 PatchSimulation patchSim = (PatchSimulation) sim;
                 Map<String, Object> eventData = new HashMap<>();
-                eventData.put("t-cell-id", cell.getID());
-                eventData.put("tissue-cell-id", target.getID());
-                eventData.put("tissue-cell-type", target.getPop());
                 eventData.put("type", "lysis");
                 eventData.put("timestamp", (int) ((PatchSimulation) sim).getSchedule().getTime());
+                eventData.put("cell-id", cell.getID());
+                eventData.put("target-cell-id", target.getID());
+                eventData.put("target-cell-type", target.getPop());
                 eventData.put(
-                        "tissue-location", ((PatchLocation) target.getLocation()).getCoordinate());
+                        "target-cell-location",
+                        ((PatchLocation) target.getLocation()).getCoordinate());
                 patchSim.logEvent(eventData);
             }
         }

--- a/src/arcade/patch/agent/module/PatchModuleProliferation.java
+++ b/src/arcade/patch/agent/module/PatchModuleProliferation.java
@@ -1,5 +1,7 @@
 package arcade.patch.agent.module;
 
+import java.util.HashMap;
+import java.util.Map;
 import sim.util.Bag;
 import ec.util.MersenneTwisterFast;
 import arcade.core.agent.cell.CellContainer;
@@ -12,6 +14,9 @@ import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.process.PatchProcess;
 import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.location.PatchLocation;
+import arcade.patch.sim.PatchSimulation;
+import arcade.patch.util.PatchEnums.Domain;
+import arcade.patch.util.PatchEnums.State;
 import static arcade.patch.util.PatchEnums.Domain;
 import static arcade.patch.util.PatchEnums.State;
 
@@ -125,6 +130,17 @@ public class PatchModuleProliferation extends PatchModule {
                         PatchProcess process = (PatchProcess) newCell.getProcess(domain);
                         process.update(cell.getProcess(domain));
                     }
+
+                    // Log proliferation event
+                    PatchSimulation patchSim = (PatchSimulation) sim;
+                    Map<String, Object> eventData = new HashMap<>();
+                    eventData.put("type", "proliferation");
+                    eventData.put(
+                            "timestamp", (int) ((PatchSimulation) sim).getSchedule().getTime());
+                    eventData.put("cell-id", cell.getID());
+                    eventData.put("cycle-length", duration);
+                    patchSim.logEvent(eventData);
+
                     // TODO: Update environment generator sites.
                 } else {
                     ticker++;

--- a/src/arcade/patch/command.patch.xml
+++ b/src/arcade/patch/command.patch.xml
@@ -1,4 +1,5 @@
 <commands>
     <switch id="SAVE_GRAPH" short="g" long="graph" help="Save the GRAPH output files" />
     <switch id="SAVE_LAYERS" short="l" long="layers" help="Save the LAYERS output files" />
+    <switch id="SAVE_EVENTS" short="e" long="events" help="Save the EVENTS output files" />
 </commands>

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -223,8 +223,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
     /**
      * Log an event to the simulation's event list.
      *
-     * @param eventType the type of event
-     * @param eventData the event data
+     * @param event logging information corresponding to the event
      */
     public void logEvent(Map<String, Object> event) {
         events.add(event);

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -4,6 +4,8 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import com.google.gson.reflect.TypeToken;
 import sim.engine.Schedule;
@@ -55,6 +57,9 @@ public abstract class PatchSimulation extends SimState implements Simulation {
     /** Cell ID tracker. */
     int id;
 
+    /** List to store events throughout the simulation. */
+    private final List<Map<String, Object>> events;
+
     /** Location factory instance for the simulation. */
     public final PatchLocationFactory locationFactory;
 
@@ -81,6 +86,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
         this.locationFactory = makeLocationFactory();
         this.cellFactory = makeCellFactory();
         this.latticeFactory = makeLatticeFactory();
+        this.events = new ArrayList<>();
     }
 
     @Override
@@ -212,6 +218,25 @@ public abstract class PatchSimulation extends SimState implements Simulation {
             locations.add(container.convert(locationFactory, null));
         }
         return locations;
+    }
+
+    /**
+     * Log an event to the simulation's event list.
+     *
+     * @param eventType the type of event
+     * @param eventData the event data
+     */
+    public void logEvent(Map<String, Object> event) {
+        events.add(event);
+    }
+
+    /**
+     * Get the list of events logged during the simulation.
+     *
+     * @return the list of events
+     */
+    public List<Map<String, Object>> getEvents() {
+        return new ArrayList<>(events);
     }
 
     /**

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -229,7 +229,7 @@ public abstract class PatchSimulation extends SimState implements Simulation {
         events.add(event);
     }
 
-    /** Clear events queue */
+    /** Clear events queue. */
     public void clearEvents() {
         events.clear();
     }

--- a/src/arcade/patch/sim/PatchSimulation.java
+++ b/src/arcade/patch/sim/PatchSimulation.java
@@ -229,6 +229,11 @@ public abstract class PatchSimulation extends SimState implements Simulation {
         events.add(event);
     }
 
+    /** Clear events queue */
+    public void clearEvents() {
+        events.clear();
+    }
+
     /**
      * Get the list of events logged during the simulation.
      *

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -1,5 +1,7 @@
 package arcade.patch.sim.output;
 
+import java.util.List;
+import java.util.Map;
 import com.google.gson.Gson;
 import arcade.core.env.component.Component;
 import arcade.core.sim.Series;
@@ -16,6 +18,9 @@ public final class PatchOutputSaver extends OutputSaver {
 
     /** {@code true} to save lattices, {@code false} otherwise. */
     public boolean saveLattice;
+
+    /** {@code true} to save events, {@code false} otherwise. */
+    public boolean saveEvents;
 
     /**
      * Creates an {@code PatchOutputSaver} for the series.
@@ -61,6 +66,22 @@ public final class PatchOutputSaver extends OutputSaver {
         write(patch, format(json, FORMAT_ELEMENTS));
     }
 
+    /**
+     * Save the collection of events to a JSON.
+     *
+     * @param tick the simulation tick
+     */
+    public void saveEventsToFile(int tick) {
+        if (saveEvents) {
+            List<Map<String, Object>> events = ((PatchSimulation) sim).getEvents();
+            if (!events.isEmpty()) {
+                String json = gson.toJson(events);
+                String path = prefix + String.format("_%06d.EVENTS.json", tick);
+                write(path, format(json, FORMAT_ELEMENTS));
+            }
+        }
+    }
+
     @Override
     public void save(int tick) {
         super.save(tick);
@@ -69,6 +90,9 @@ public final class PatchOutputSaver extends OutputSaver {
         }
         if (saveLattice) {
             saveLayers(tick);
+        }
+        if (saveEvents) {
+            saveEventsToFile(tick);
         }
     }
 }

--- a/src/arcade/patch/sim/output/PatchOutputSaver.java
+++ b/src/arcade/patch/sim/output/PatchOutputSaver.java
@@ -67,7 +67,7 @@ public final class PatchOutputSaver extends OutputSaver {
     }
 
     /**
-     * Save the collection of events to a JSON.
+     * Save the collection of events to a JSON. Clears events queue after writing to file.
      *
      * @param tick the simulation tick
      */
@@ -78,6 +78,7 @@ public final class PatchOutputSaver extends OutputSaver {
                 String json = gson.toJson(events);
                 String path = prefix + String.format("_%06d.EVENTS.json", tick);
                 write(path, format(json, FORMAT_ELEMENTS));
+                ((PatchSimulation) sim).clearEvents();
             }
         }
     }

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -3,6 +3,7 @@ package arcade.patch.agent.module;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import sim.engine.Schedule;
 import ec.util.MersenneTwisterFast;
 import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCellCART;
@@ -28,6 +29,8 @@ public class PatchModuleCytotoxicityTest {
 
     private PatchLocation mockLocation;
 
+    private Schedule mockSchedule;
+
     private MersenneTwisterFast randomMock;
 
     @BeforeEach
@@ -36,6 +39,7 @@ public class PatchModuleCytotoxicityTest {
         mockTarget = mock(PatchCellTissue.class);
         mockInflammation = mock(PatchProcessInflammation.class);
         mockLocation = mock(PatchLocation.class);
+        mockSchedule = mock(Schedule.class);
 
         sim = mock(PatchSimulation.class);
         randomMock = mock(MersenneTwisterFast.class);
@@ -53,7 +57,8 @@ public class PatchModuleCytotoxicityTest {
         when(mockTarget.getLocation()).thenReturn(mockLocation);
 
         when(mockLocation.getCoordinate()).thenReturn(mock(Coordinate.class));
-        when(sim.getSchedule().getTime()).thenReturn(0.0);
+        when(sim.getSchedule()).thenReturn(mockSchedule);
+        when(mockSchedule.getTime()).thenReturn(0.0);
 
         action = new PatchModuleCytotoxicity(mockCell);
     }

--- a/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
+++ b/test/arcade/patch/agent/module/PatchModuleCytotoxicityTest.java
@@ -8,6 +8,8 @@ import arcade.core.util.Parameters;
 import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.agent.process.PatchProcessInflammation;
+import arcade.patch.env.location.Coordinate;
+import arcade.patch.env.location.PatchLocation;
 import arcade.patch.sim.PatchSimulation;
 import arcade.patch.util.PatchEnums.State;
 import static org.mockito.Mockito.*;
@@ -24,6 +26,8 @@ public class PatchModuleCytotoxicityTest {
 
     private PatchSimulation sim;
 
+    private PatchLocation mockLocation;
+
     private MersenneTwisterFast randomMock;
 
     @BeforeEach
@@ -31,6 +35,8 @@ public class PatchModuleCytotoxicityTest {
         mockCell = mock(PatchCellCART.class);
         mockTarget = mock(PatchCellTissue.class);
         mockInflammation = mock(PatchProcessInflammation.class);
+        mockLocation = mock(PatchLocation.class);
+
         sim = mock(PatchSimulation.class);
         randomMock = mock(MersenneTwisterFast.class);
         Parameters parameters = mock(Parameters.class);
@@ -41,6 +47,13 @@ public class PatchModuleCytotoxicityTest {
         when(mockCell.getProcess(any())).thenReturn(mockInflammation);
         when(mockInflammation.getInternal("granzyme")).thenReturn(1.0);
         when(mockCell.getBoundTarget()).thenReturn(mockTarget);
+        when(mockCell.getID()).thenReturn(1);
+        when(mockTarget.getID()).thenReturn(1);
+        when(mockTarget.getPop()).thenReturn(1);
+        when(mockTarget.getLocation()).thenReturn(mockLocation);
+
+        when(mockLocation.getCoordinate()).thenReturn(mock(Coordinate.class));
+        when(sim.getSchedule().getTime()).thenReturn(0.0);
 
         action = new PatchModuleCytotoxicity(mockCell);
     }


### PR DESCRIPTION
Estimated time to review: small

Addresses #191 

Description of changes:
- added CLI option for logging events
- added an 'EVENTS' output file logging events that occur at given tick intervals
- added logging information to cytotoxic module to track lysis events & proliferation module to track division events and cycle length
- edit tests to include new mocks for event logging

Discussion:
- [x] We can consider logging division as an event as a proxy for cell cycle durations 
    - Then we would just need to add logging into the proliferation state module instead of changing all the cell containers as mentioned in #206
- [x] I am concerned about the events queue object getting exponentially larger if we start tracking frequent events, we should discuss clearing the queue once the events are logged