### PR TITLE
Adding ComponentType enum for PatchComponentSites

### DIFF
--- a/src/arcade/patch/env/component/PatchComponentSites.java
+++ b/src/arcade/patch/env/component/PatchComponentSites.java
@@ -8,6 +8,9 @@ import arcade.core.env.operation.Operation;
 import arcade.core.sim.Series;
 import arcade.core.sim.Simulation;
 import arcade.patch.env.operation.PatchOperationGenerator;
+import arcade.patch.util.PatchEnums.Category;
+import arcade.patch.util.PatchEnums.ComponentType;
+import arcade.patch.util.PatchEnums.Ordering;
 import static arcade.patch.util.PatchEnums.Category;
 import static arcade.patch.util.PatchEnums.Ordering;
 
@@ -93,4 +96,11 @@ public abstract class PatchComponentSites implements Component {
         SiteLayer siteLayer = new SiteLayer(layer, (PatchOperationGenerator) generator);
         layers.add(siteLayer);
     }
+
+    /**
+     * Returns what type of {@code ComponentType} this is
+     *
+     * @return the component type
+     */
+    public abstract ComponentType getComponentType();
 }

--- a/src/arcade/patch/env/component/PatchComponentSites.java
+++ b/src/arcade/patch/env/component/PatchComponentSites.java
@@ -98,7 +98,7 @@ public abstract class PatchComponentSites implements Component {
     }
 
     /**
-     * Returns what type of {@code ComponentType} this is
+     * Returns what type of {@code ComponentType} this is.
      *
      * @return the component type
      */

--- a/src/arcade/patch/env/component/PatchComponentSitesGraph.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesGraph.java
@@ -13,8 +13,12 @@ import arcade.core.util.Graph.Node;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Solver;
 import arcade.core.util.Solver.Function;
+import arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeLevel;
+import arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeTag;
+import arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeType;
 import arcade.patch.env.location.CoordinateXYZ;
 import arcade.patch.sim.PatchSeries;
+import arcade.patch.util.PatchEnums.ComponentType;
 import static arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeLevel;
 import static arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeTag;
 import static arcade.patch.env.component.PatchComponentSitesGraphFactory.EdgeType;
@@ -854,5 +858,10 @@ public abstract class PatchComponentSitesGraph extends PatchComponentSites {
         }
 
         return children;
+    }
+
+    @Override
+    public ComponentType getComponentType() {
+        return ComponentType.GRAPH;
     }
 }

--- a/src/arcade/patch/env/component/PatchComponentSitesPattern.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesPattern.java
@@ -4,6 +4,7 @@ import java.util.EnumMap;
 import sim.engine.SimState;
 import arcade.core.sim.Series;
 import arcade.core.util.MiniBox;
+import arcade.patch.util.PatchEnums.ComponentType;
 
 /**
  * Extension of {@link PatchComponentSites} for pattern sites.
@@ -308,4 +309,9 @@ public abstract class PatchComponentSitesPattern extends PatchComponentSites {
     //            int zOld = oldLoc.getLatZ();
     //            for (int[] i : oldLoc.getLatLocations()) { damageSingle[zOld][i[0]][i[1]]++; }
     //        }
+
+    @Override
+    public ComponentType getComponentType() {
+        return ComponentType.PATTERN;
+    }
 }

--- a/src/arcade/patch/env/component/PatchComponentSitesSource.java
+++ b/src/arcade/patch/env/component/PatchComponentSitesSource.java
@@ -3,6 +3,7 @@ package arcade.patch.env.component;
 import sim.engine.SimState;
 import arcade.core.sim.Series;
 import arcade.core.util.MiniBox;
+import arcade.patch.util.PatchEnums.ComponentType;
 
 /**
  * Extension of {@link PatchComponentSites} for source sites.
@@ -225,4 +226,9 @@ public class PatchComponentSitesSource extends PatchComponentSites {
     //            int zOld = oldLoc.getLatZ();
     //            for (int[] i : oldLoc.getLatLocations()) { damageSingle[zOld][i[0]][i[1]]++; }
     //        }
+
+    @Override
+    public ComponentType getComponentType() {
+        return ComponentType.SOURCE;
+    }
 }

--- a/src/arcade/patch/util/PatchEnums.java
+++ b/src/arcade/patch/util/PatchEnums.java
@@ -224,4 +224,26 @@ public final class PatchEnums {
             return values()[rng.nextInt(values().length - 1) + 1];
         }
     }
+
+    /** Enum for component types. */
+    public enum ComponentType {
+        /** Code for graph component. */
+        GRAPH,
+
+        /** Code for source component. */
+        SOURCE,
+
+        /** Code for pattern component. */
+        PATTERN;
+
+        /**
+         * Randomly selects a {@code ComponentType}.
+         *
+         * @param rng the random number generator
+         * @return a random {@code ComponentType}
+         */
+        public static ComponentType random(MersenneTwisterFast rng) {
+            return values()[rng.nextInt(values().length - 1) + 1];
+        }
+    }
 }


### PR DESCRIPTION
**Anticipated review time:** _xs_

**Description:** 
- I added enums to describe the component type for PatchComponentSites. 
- I also an abstract method with method implementations in each subclass so that the components can return the ComponentType enum associated with the class. 

This is PR is in anticipation of the Treat class for the CARCADE refactor, I thought it would be more modular for this to be its own PR instead of lumping it together with Treat. 