### PR TITLE
Factored checkLocationSpace into multiple methods in PatchUtilities

### DIFF
--- a/src/arcade/patch/agent/action/PatchActionTreat.java
+++ b/src/arcade/patch/agent/action/PatchActionTreat.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import arcade.patch.util.PatchUtilities;
 import sim.engine.Schedule;
 import sim.engine.SimState;
 import sim.util.Bag;
@@ -17,9 +19,7 @@ import arcade.core.util.Graph;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Utilities;
 import arcade.patch.agent.cell.PatchCell;
-import arcade.patch.agent.cell.PatchCellCART;
 import arcade.patch.agent.cell.PatchCellContainer;
-import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.env.component.PatchComponentSites;
 import arcade.patch.env.component.PatchComponentSitesGraph;
 import arcade.patch.env.component.PatchComponentSitesGraph.SiteEdge;
@@ -332,43 +332,46 @@ public class PatchActionTreat implements Action {
      * @return boolean indicating if location is free
      */
     protected boolean checkLocationSpace(Location loc, PatchGrid grid) {
-        boolean available;
-        int locMax = this.maxConfluency;
-        double locVolume = ((PatchLocation) loc).getVolume();
-        double locArea = ((PatchLocation) loc).getArea();
 
-        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
-        int n = bag.numObjs; // number of agents in location
-
-        if (n == 0) {
-            // no cells in location
-            available = true;
-        } else if (n >= locMax) {
-            // location already full
-            available = false;
-        } else {
-            available = true;
-            double totalVol = PatchCell.calculateTotalVolume(bag);
-            double currentHeight = totalVol / locArea;
-
-            if (totalVol > locVolume) {
-                available = false;
-            }
-
-            for (Object cellObj : bag) {
-                PatchCell cell = (PatchCell) cellObj;
-                if (cell instanceof PatchCellCART) {
-                    totalVol = PatchCell.calculateTotalVolume(bag) + cell.getVolume();
-                    currentHeight = totalVol / locArea;
-                }
-                if (cell instanceof PatchCellTissue) {
-                    if (currentHeight > cell.getCriticalHeight()) {
-                        available = false;
-                    }
-                }
-            }
-        }
-
-        return available;
+        //        boolean available;
+        //        int locMax = this.maxConfluency;
+        //        double locVolume = ((PatchLocation) loc).getVolume();
+        //        double locArea = ((PatchLocation) loc).getArea();
+        //
+        //        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
+        //        int n = bag.numObjs; // number of agents in location
+        //
+        //        if (n == 0) {
+        //            // no cells in location
+        //            available = true;
+        //        } else if (n >= locMax) {
+        //            // location already full
+        //            available = false;
+        //        } else {
+        //            available = true;
+        //            double totalVol = PatchCell.calculateTotalVolume(bag);
+        //            double currentHeight = totalVol / locArea;
+        //
+        //            if (totalVol > locVolume) {
+        //                available = false;
+        //            }
+        //
+        //            for (Object cellObj : bag) {
+        //                PatchCell cell = (PatchCell) cellObj;
+        //                if (cell instanceof PatchCellCART) {
+        //                    totalVol = PatchCell.calculateTotalVolume(bag) + cell.getVolume();
+        //                    currentHeight = totalVol / locArea;
+        //                }
+        //                if (cell instanceof PatchCellTissue) {
+        //                    if (currentHeight > cell.getCriticalHeight()) {
+        //                        available = false;
+        //                    }
+        //                }
+        //            }
+        //        }
+        //
+        //        return available;
+        return PatchUtilities.checkLocation(
+                (PatchLocation) loc, grid, 0, null, null, null, this.maxConfluency, false);
     }
 }

--- a/src/arcade/patch/agent/action/PatchActionTreat.java
+++ b/src/arcade/patch/agent/action/PatchActionTreat.java
@@ -5,8 +5,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import arcade.patch.util.PatchUtilities;
 import sim.engine.Schedule;
 import sim.engine.SimState;
 import sim.util.Bag;
@@ -34,6 +32,7 @@ import arcade.patch.sim.PatchSimulation;
 import arcade.patch.util.PatchEnums.ComponentType;
 import arcade.patch.util.PatchEnums.Immune;
 import arcade.patch.util.PatchEnums.Ordering;
+import arcade.patch.util.PatchUtilities;
 
 /**
  * Implementation of {@link Action} for inserting T-cell agents.
@@ -371,7 +370,9 @@ public class PatchActionTreat implements Action {
         //        }
         //
         //        return available;
-        return PatchUtilities.checkLocation(
-                (PatchLocation) loc, grid, 0, null, null, null, this.maxConfluency, false);
+        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
+        return PatchUtilities.checkLocationHeight((PatchLocation) loc, bag, 0, null, false)
+                && PatchUtilities.checkLocationOccupancy(
+                        bag, (PatchLocation) loc, this.maxConfluency, 0);
     }
 }

--- a/src/arcade/patch/agent/action/PatchActionTreat.java
+++ b/src/arcade/patch/agent/action/PatchActionTreat.java
@@ -332,44 +332,6 @@ public class PatchActionTreat implements Action {
      */
     protected boolean checkLocationSpace(Location loc, PatchGrid grid) {
 
-        //        boolean available;
-        //        int locMax = this.maxConfluency;
-        //        double locVolume = ((PatchLocation) loc).getVolume();
-        //        double locArea = ((PatchLocation) loc).getArea();
-        //
-        //        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
-        //        int n = bag.numObjs; // number of agents in location
-        //
-        //        if (n == 0) {
-        //            // no cells in location
-        //            available = true;
-        //        } else if (n >= locMax) {
-        //            // location already full
-        //            available = false;
-        //        } else {
-        //            available = true;
-        //            double totalVol = PatchCell.calculateTotalVolume(bag);
-        //            double currentHeight = totalVol / locArea;
-        //
-        //            if (totalVol > locVolume) {
-        //                available = false;
-        //            }
-        //
-        //            for (Object cellObj : bag) {
-        //                PatchCell cell = (PatchCell) cellObj;
-        //                if (cell instanceof PatchCellCART) {
-        //                    totalVol = PatchCell.calculateTotalVolume(bag) + cell.getVolume();
-        //                    currentHeight = totalVol / locArea;
-        //                }
-        //                if (cell instanceof PatchCellTissue) {
-        //                    if (currentHeight > cell.getCriticalHeight()) {
-        //                        available = false;
-        //                    }
-        //                }
-        //            }
-        //        }
-        //
-        //        return available;
         Bag bag = new Bag(grid.getObjectsAtLocation(loc));
         return PatchUtilities.checkLocationHeight((PatchLocation) loc, bag, 0, null, false)
                 && PatchUtilities.checkLocationOccupancy(

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -2,8 +2,6 @@ package arcade.patch.agent.cell;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import arcade.patch.util.PatchUtilities;
 import sim.engine.Schedule;
 import sim.engine.Stoppable;
 import sim.util.Bag;
@@ -19,7 +17,6 @@ import arcade.core.sim.Simulation;
 import arcade.core.util.GrabBag;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Parameters;
-import arcade.core.util.Utilities;
 import arcade.patch.agent.module.PatchModuleApoptosis;
 import arcade.patch.agent.module.PatchModuleCytotoxicity;
 import arcade.patch.agent.module.PatchModuleMigration;
@@ -35,6 +32,7 @@ import arcade.patch.agent.process.PatchProcessSignaling;
 import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.location.PatchLocation;
 import arcade.patch.util.PatchEnums;
+import arcade.patch.util.PatchUtilities;
 import static arcade.patch.util.PatchEnums.Domain;
 import static arcade.patch.util.PatchEnums.Flag;
 import static arcade.patch.util.PatchEnums.Ordering;
@@ -566,15 +564,10 @@ public abstract class PatchCell implements Cell {
         //            }
         //        }
         //        return true;
-        return PatchUtilities.checkLocation(
-                loc,
-                (PatchGrid) sim.getGrid(),
-                addedVolume,
-                maxHeight,
-                population,
-                maxDensity,
-                null,
-                true);
+        Bag bag = new Bag(((PatchGrid) sim.getGrid()).getObjectsAtLocation(loc));
+        return PatchUtilities.checkLocationOccupancy(bag, loc, null, addedVolume)
+                && PatchUtilities.checkLocationDensity(loc, bag, population, maxDensity)
+                && PatchUtilities.checkLocationHeight(loc, bag, addedVolume, maxHeight, true);
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -2,6 +2,8 @@ package arcade.patch.agent.cell;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import arcade.patch.util.PatchUtilities;
 import sim.engine.Schedule;
 import sim.engine.Stoppable;
 import sim.util.Bag;
@@ -17,6 +19,7 @@ import arcade.core.sim.Simulation;
 import arcade.core.util.GrabBag;
 import arcade.core.util.MiniBox;
 import arcade.core.util.Parameters;
+import arcade.core.util.Utilities;
 import arcade.patch.agent.module.PatchModuleApoptosis;
 import arcade.patch.agent.module.PatchModuleCytotoxicity;
 import arcade.patch.agent.module.PatchModuleMigration;
@@ -534,35 +537,44 @@ public abstract class PatchCell implements Cell {
             double maxHeight,
             int population,
             int maxDensity) {
-        double locationVolume = loc.getVolume();
-        double locationArea = loc.getArea();
-        PatchGrid grid = (PatchGrid) sim.getGrid();
-
-        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
-
-        if (bag.numObjs != 0) {
-            double proposedVolume = calculateTotalVolume(bag) + addedVolume;
-            double proposedHeight = proposedVolume / locationArea;
-
-            if (proposedVolume > locationVolume || proposedHeight > maxHeight) {
-                return false;
-            }
-
-            int count = 0;
-            for (Object obj : bag) {
-                PatchCell cell = (PatchCell) obj;
-                if (proposedHeight > cell.getCriticalHeight()) {
-                    return false;
-                }
-                if (cell.getPop() == population) {
-                    count++;
-                    if (count >= maxDensity) {
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
+        //        double locationVolume = loc.getVolume();
+        //        double locationArea = loc.getArea();
+        //        PatchGrid grid = (PatchGrid) sim.getGrid();
+        //
+        //        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
+        //
+        //        if (bag.numObjs != 0) {
+        //            double proposedVolume = calculateTotalVolume(bag) + addedVolume;
+        //            double proposedHeight = proposedVolume / locationArea;
+        //
+        //            if (proposedVolume > locationVolume || proposedHeight > maxHeight) {
+        //                return false;
+        //            }
+        //
+        //            int count = 0;
+        //            for (Object obj : bag) {
+        //                PatchCell cell = (PatchCell) obj;
+        //                if (proposedHeight > cell.getCriticalHeight()) {
+        //                    return false;
+        //                }
+        //                if (cell.getPop() == population) {
+        //                    count++;
+        //                    if (count >= maxDensity) {
+        //                        return false;
+        //                    }
+        //                }
+        //            }
+        //        }
+        //        return true;
+        return PatchUtilities.checkLocation(
+                loc,
+                (PatchGrid) sim.getGrid(),
+                addedVolume,
+                maxHeight,
+                population,
+                maxDensity,
+                null,
+                true);
     }
 
     /**

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -535,35 +535,7 @@ public abstract class PatchCell implements Cell {
             double maxHeight,
             int population,
             int maxDensity) {
-        //        double locationVolume = loc.getVolume();
-        //        double locationArea = loc.getArea();
-        //        PatchGrid grid = (PatchGrid) sim.getGrid();
-        //
-        //        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
-        //
-        //        if (bag.numObjs != 0) {
-        //            double proposedVolume = calculateTotalVolume(bag) + addedVolume;
-        //            double proposedHeight = proposedVolume / locationArea;
-        //
-        //            if (proposedVolume > locationVolume || proposedHeight > maxHeight) {
-        //                return false;
-        //            }
-        //
-        //            int count = 0;
-        //            for (Object obj : bag) {
-        //                PatchCell cell = (PatchCell) obj;
-        //                if (proposedHeight > cell.getCriticalHeight()) {
-        //                    return false;
-        //                }
-        //                if (cell.getPop() == population) {
-        //                    count++;
-        //                    if (count >= maxDensity) {
-        //                        return false;
-        //                    }
-        //                }
-        //            }
-        //        }
-        //        return true;
+
         Bag bag = new Bag(((PatchGrid) sim.getGrid()).getObjectsAtLocation(loc));
         return PatchUtilities.checkLocationOccupancy(bag, loc, null, addedVolume)
                 && PatchUtilities.checkLocationDensity(bag, population, maxDensity)

--- a/src/arcade/patch/agent/cell/PatchCell.java
+++ b/src/arcade/patch/agent/cell/PatchCell.java
@@ -566,7 +566,7 @@ public abstract class PatchCell implements Cell {
         //        return true;
         Bag bag = new Bag(((PatchGrid) sim.getGrid()).getObjectsAtLocation(loc));
         return PatchUtilities.checkLocationOccupancy(bag, loc, null, addedVolume)
-                && PatchUtilities.checkLocationDensity(loc, bag, population, maxDensity)
+                && PatchUtilities.checkLocationDensity(bag, population, maxDensity)
                 && PatchUtilities.checkLocationHeight(loc, bag, addedVolume, maxHeight, true);
     }
 

--- a/src/arcade/patch/util/PatchUtilities.java
+++ b/src/arcade/patch/util/PatchUtilities.java
@@ -1,4 +1,72 @@
 package arcade.patch.util;
 
-public class Utilities {
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.env.grid.PatchGrid;
+import arcade.patch.env.location.PatchLocation;
+import sim.util.Bag;
+
+public class PatchUtilities {
+    public final class Utilities {
+        /**
+         * Hidden utility class constructor.
+         */
+        protected Utilities() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+    public static boolean checkLocation(
+            PatchLocation loc,
+            PatchGrid grid,
+            double addedVolume,
+            Double maxHeight,
+            Integer population,
+            Integer maxDensity,
+            Integer maxOccupancy,
+            boolean checkAllCriticalHeights) {
+
+        double locationVolume = loc.getVolume();
+        double locationArea = loc.getArea();
+
+        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
+        int n = bag.numObjs; // number of agents in location
+
+        if (n == 0) return true;
+
+        if (maxOccupancy != null && n >= maxOccupancy) {
+            return false;
+        }
+
+        double proposedVolume = PatchCell.calculateTotalVolume(bag) + addedVolume;
+        double proposedHeight = proposedVolume / locationArea;
+
+        if (proposedVolume > locationVolume) {
+            return false;
+        }
+
+        if (maxHeight != null && proposedHeight > maxHeight) {
+            return false;
+        }
+
+        int count = 0;
+        for (Object obj : bag) {
+            PatchCell cell = (PatchCell) obj;
+            if (checkAllCriticalHeights || cell instanceof PatchCellTissue) {
+                if (proposedHeight > cell.getCriticalHeight()) {
+                    return false;
+                }
+            }
+            if (population != null && maxDensity != null) {
+                if (cell.getPop() == population) {
+                    count++;
+                    if (count >= maxDensity) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/src/arcade/patch/util/PatchUtilities.java
+++ b/src/arcade/patch/util/PatchUtilities.java
@@ -1,0 +1,4 @@
+package arcade.patch.util;
+
+public class Utilities {
+}

--- a/src/arcade/patch/util/PatchUtilities.java
+++ b/src/arcade/patch/util/PatchUtilities.java
@@ -1,56 +1,33 @@
 package arcade.patch.util;
 
+import sim.util.Bag;
 import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellTissue;
-import arcade.patch.env.grid.PatchGrid;
 import arcade.patch.env.location.PatchLocation;
-import sim.util.Bag;
 
 public class PatchUtilities {
     public final class Utilities {
-        /**
-         * Hidden utility class constructor.
-         */
+        /** Hidden utility class constructor. */
         protected Utilities() {
             throw new UnsupportedOperationException();
         }
-
     }
 
-    public static boolean checkLocation(
+    public static boolean checkLocationHeight(
             PatchLocation loc,
-            PatchGrid grid,
+            Bag bag,
             double addedVolume,
             Double maxHeight,
-            Integer population,
-            Integer maxDensity,
-            Integer maxOccupancy,
             boolean checkAllCriticalHeights) {
 
-        double locationVolume = loc.getVolume();
-        double locationArea = loc.getArea();
-
-        Bag bag = new Bag(grid.getObjectsAtLocation(loc));
-        int n = bag.numObjs; // number of agents in location
-
-        if (n == 0) return true;
-
-        if (maxOccupancy != null && n >= maxOccupancy) {
-            return false;
+        if (bag.numObjs == 0) {
+            return true;
         }
-
-        double proposedVolume = PatchCell.calculateTotalVolume(bag) + addedVolume;
-        double proposedHeight = proposedVolume / locationArea;
-
-        if (proposedVolume > locationVolume) {
-            return false;
-        }
-
+        double proposedHeight = (PatchCell.calculateTotalVolume(bag) + addedVolume) / loc.getArea();
         if (maxHeight != null && proposedHeight > maxHeight) {
             return false;
         }
 
-        int count = 0;
         for (Object obj : bag) {
             PatchCell cell = (PatchCell) obj;
             if (checkAllCriticalHeights || cell instanceof PatchCellTissue) {
@@ -58,15 +35,38 @@ public class PatchUtilities {
                     return false;
                 }
             }
-            if (population != null && maxDensity != null) {
-                if (cell.getPop() == population) {
-                    count++;
-                    if (count >= maxDensity) {
-                        return false;
-                    }
-                }
+        }
+
+        return true;
+    }
+
+    public static boolean checkLocationDensity(
+            PatchLocation loc, Bag bag, Integer population, Integer maxDensity) {
+        if (population == null || maxDensity == null) {
+            return true;
+        }
+        int count = 0;
+        for (Object obj : bag) {
+            PatchCell cell = (PatchCell) obj;
+            if (cell.getPop() == population) {
+                count++;
+                if (count >= maxDensity) return false;
             }
         }
+
         return true;
+    }
+
+    public static boolean checkLocationOccupancy(
+            Bag bag, PatchLocation loc, Integer maxOccupancy, double addedVolume) {
+        int n = bag.numObjs; // number of agents in location
+
+        if (n == 0) {
+            return true;
+        }
+        if (maxOccupancy != null && n >= maxOccupancy) {
+            return false;
+        }
+        return !(PatchCell.calculateTotalVolume(bag) + addedVolume > loc.getVolume());
     }
 }

--- a/src/arcade/patch/util/PatchUtilities.java
+++ b/src/arcade/patch/util/PatchUtilities.java
@@ -5,12 +5,10 @@ import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.env.location.PatchLocation;
 
-public class PatchUtilities {
-    public final class Utilities {
-        /** Hidden utility class constructor. */
-        protected Utilities() {
-            throw new UnsupportedOperationException();
-        }
+public final class PatchUtilities {
+
+    protected PatchUtilities() {
+        throw new UnsupportedOperationException();
     }
 
     public static boolean checkLocationHeight(
@@ -40,8 +38,7 @@ public class PatchUtilities {
         return true;
     }
 
-    public static boolean checkLocationDensity(
-            PatchLocation loc, Bag bag, Integer population, Integer maxDensity) {
+    public static boolean checkLocationDensity(Bag bag, Integer population, Integer maxDensity) {
         if (population == null || maxDensity == null) {
             return true;
         }

--- a/src/arcade/patch/util/PatchUtilities.java
+++ b/src/arcade/patch/util/PatchUtilities.java
@@ -5,12 +5,25 @@ import arcade.patch.agent.cell.PatchCell;
 import arcade.patch.agent.cell.PatchCellTissue;
 import arcade.patch.env.location.PatchLocation;
 
+/** Utility class providing static helper methods for patch simulations. */
 public final class PatchUtilities {
 
+    /** Hidden utility class constructor. */
     protected PatchUtilities() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Checks if the proposed height of a cell added to a location does not exceed height
+     * constraints.
+     *
+     * @param loc the location
+     * @param bag the cells currently in the location
+     * @param addedVolume the volume of the cell being added
+     * @param maxHeight the maximum height tolerance, or null to skip
+     * @param checkAllCriticalHeights true to check all cells, false to check only tissue cells
+     * @return true if the location height is within constraints, false otherwise
+     */
     public static boolean checkLocationHeight(
             PatchLocation loc,
             Bag bag,
@@ -38,22 +51,39 @@ public final class PatchUtilities {
         return true;
     }
 
-    public static boolean checkLocationDensity(Bag bag, Integer population, Integer maxDensity) {
-        if (population == null || maxDensity == null) {
-            return true;
-        }
+    /**
+     * Checks if the number of cells of a given population in a location does not exceed the maximum
+     * density.
+     *
+     * @param bag the cells currently in the location
+     * @param population the population index to check
+     * @param maxDensity the maximum number of cells of the population allowed
+     * @return true if the population density is within the maximum, false otherwise
+     */
+    public static boolean checkLocationDensity(Bag bag, int population, int maxDensity) {
         int count = 0;
         for (Object obj : bag) {
             PatchCell cell = (PatchCell) obj;
             if (cell.getPop() == population) {
                 count++;
-                if (count >= maxDensity) return false;
+                if (count >= maxDensity) {
+                    return false;
+                }
             }
         }
 
         return true;
     }
 
+    /**
+     * Checks if the proposed volume added to a location does not exceed the location volume.
+     *
+     * @param bag the cells currently in the location
+     * @param loc the location
+     * @param maxOccupancy the maximum number of cells allowed in the location, or null to skip
+     * @param addedVolume the volume of the cell being added
+     * @return true if the location has sufficient volume, false otherwise
+     */
     public static boolean checkLocationOccupancy(
             Bag bag, PatchLocation loc, Integer maxOccupancy, double addedVolume) {
         int n = bag.numObjs; // number of agents in location

--- a/test/arcade/patch/util/PatchUtilitiesTest.java
+++ b/test/arcade/patch/util/PatchUtilitiesTest.java
@@ -1,0 +1,155 @@
+package arcade.patch.util;
+
+import org.junit.jupiter.api.Test;
+import sim.util.Bag;
+import arcade.patch.agent.cell.PatchCell;
+import arcade.patch.agent.cell.PatchCellTissue;
+import arcade.patch.env.location.PatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class PatchUtilitiesTest {
+
+    @Test
+    public void constructor_called_throwsException() {
+        assertThrows(UnsupportedOperationException.class, PatchUtilities::new);
+    }
+
+    @Test
+    public void checkLocationHeight_emptyBag_returnsTrue() {
+        PatchLocation loc = mock(PatchLocation.class);
+        Bag bag = new Bag();
+
+        assertTrue(PatchUtilities.checkLocationHeight(loc, bag, 0, null, false));
+    }
+
+    @Test
+    public void checkLocationHeight_proposedHeightExceedsMaxHeight_returnsFalse() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(1.0).when(loc).getArea();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertFalse(PatchUtilities.checkLocationHeight(loc, bag, 1, 10.0, false));
+    }
+
+    @Test
+    public void checkLocationHeight_checkAllCriticalHeights_exceedsCriticalHeight_returnsFalse() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(1.0).when(loc).getArea();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        doReturn(1.0).when(cell).getCriticalHeight();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertFalse(PatchUtilities.checkLocationHeight(loc, bag, 0, null, true));
+    }
+
+    @Test
+    public void checkLocationHeight_checkAllCriticalHeights_belowCriticalHeight_returnsTrue() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(1.0).when(loc).getArea();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        doReturn(10.0).when(cell).getCriticalHeight();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertTrue(PatchUtilities.checkLocationHeight(loc, bag, 0, null, true));
+    }
+
+    @Test
+    public void checkLocationHeight_checkAllCriticalHeightsFalse_nonTissueCell_returnsTrue() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(1.0).when(loc).getArea();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        doReturn(1.0).when(cell).getCriticalHeight();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertTrue(PatchUtilities.checkLocationHeight(loc, bag, 0, null, false));
+    }
+
+    @Test
+    public void checkLocationHeight_checkAllCriticalHeightsFalse_tissueCell_checksHeight() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(1.0).when(loc).getArea();
+        PatchCellTissue cell = mock(PatchCellTissue.class);
+        doReturn(10.0).when(cell).getVolume();
+        doReturn(9.0).when(cell).getCriticalHeight();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertFalse(PatchUtilities.checkLocationHeight(loc, bag, 0, null, false));
+    }
+
+    @Test
+    public void checkLocationDensity_nullParameters_returnsTrue() {
+        Bag bag = new Bag();
+        bag.add(mock(PatchCell.class));
+        assertTrue(PatchUtilities.checkLocationDensity(bag, null, 2));
+        assertTrue(PatchUtilities.checkLocationDensity(bag, 0, null));
+    }
+
+    @Test
+    public void checkLocationDensity_atMaxDensity_returnsFalse() {
+        PatchCell cell1 = mock(PatchCell.class);
+        PatchCell cell2 = mock(PatchCell.class);
+        PatchCell cell3 = mock(PatchCell.class);
+        doReturn(1).when(cell1).getPop();
+        doReturn(0).when(cell2).getPop();
+        doReturn(1).when(cell2).getPop();
+        Bag bag = new Bag();
+        bag.add(cell1);
+        bag.add(cell2);
+        bag.add(cell3);
+        assertFalse(PatchUtilities.checkLocationDensity(bag, 1, 2));
+    }
+
+    @Test
+    public void checkLocationDensity_belowMaxDensity_returnsTrue() {
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(1).when(cell).getPop();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertTrue(PatchUtilities.checkLocationDensity(bag, 1, 2));
+    }
+
+    @Test
+    public void checkLocationOccupancy_emptyBag_returnsTrue() {
+        PatchLocation loc = mock(PatchLocation.class);
+        Bag bag = new Bag();
+
+        assertTrue(PatchUtilities.checkLocationOccupancy(bag, loc, null, 50.0));
+    }
+
+    @Test
+    public void checkLocationOccupancy_atMaxOccupancy_returnsFalse() {
+        PatchLocation loc = mock(PatchLocation.class);
+        Bag bag = new Bag();
+        bag.add(mock(PatchCell.class));
+        bag.add(mock(PatchCell.class));
+        assertFalse(PatchUtilities.checkLocationOccupancy(bag, loc, 2, 0));
+    }
+
+    @Test
+    public void checkLocationOccupancy_volumeExceeded_returnsFalse() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(100.0).when(loc).getVolume();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertFalse(PatchUtilities.checkLocationOccupancy(bag, loc, null, 100));
+    }
+
+    @Test
+    public void checkLocationOccupancy_volumeNotExceeded_returnsTrue() {
+        PatchLocation loc = mock(PatchLocation.class);
+        doReturn(110.0).when(loc).getVolume();
+        PatchCell cell = mock(PatchCell.class);
+        doReturn(10.0).when(cell).getVolume();
+        Bag bag = new Bag();
+        bag.add(cell);
+        assertTrue(PatchUtilities.checkLocationOccupancy(bag, loc, null, 100));
+    }
+}

--- a/test/arcade/patch/util/PatchUtilitiesTest.java
+++ b/test/arcade/patch/util/PatchUtilitiesTest.java
@@ -83,14 +83,6 @@ public class PatchUtilitiesTest {
     }
 
     @Test
-    public void checkLocationDensity_nullParameters_returnsTrue() {
-        Bag bag = new Bag();
-        bag.add(mock(PatchCell.class));
-        assertTrue(PatchUtilities.checkLocationDensity(bag, null, 2));
-        assertTrue(PatchUtilities.checkLocationDensity(bag, 0, null));
-    }
-
-    @Test
     public void checkLocationDensity_atMaxDensity_returnsFalse() {
         PatchCell cell1 = mock(PatchCell.class);
         PatchCell cell2 = mock(PatchCell.class);


### PR DESCRIPTION
Estimated time to review: small

- created new `PatchUtilities` and `PatchUtilitiesTest` files to contain factored static methods
- factored out checking location space into three methods: density, height, and occupancy
- wrote tests for these three methods

Resolves #215
